### PR TITLE
Remove JTO dependency

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -8,22 +8,15 @@ object Version {
   val play          = "2.4.2"
   val playTest      = "2.4.2"
   val scalaz        = "7.2.0"
-  val scalaXml      = "1.0.3"
   val specs2        = "3.7.2"
-  val jtoValidationCore = "1.1"
-  val jtoValidationJson = "1.1"
   val guava         = "19.0"
 }
 
 object Library {
   val guava         = "com.google.guava"  % "guava"                   % Version.guava
   val scalaz        = "org.scalaz"        %% "scalaz-core"            % Version.scalaz
-  val play          = "com.typesafe.play" %% "play"                   % Version.play
   val playJson      = "com.typesafe.play" %% "play-json"              % Version.play
   val playWs        = "com.typesafe.play" %% "play-ws"                % Version.play
-  val scalaXml      = "org.scala-lang.modules" %% "scala-xml" % "1.0.3"
-  val jtoValidationCore = "io.github.jto" %% "validation-core"        % Version.jtoValidationCore
-  val jtoValidationJson = "io.github.jto" %% "validation-json"        % Version.jtoValidationJson
   val playTest      = "com.typesafe.play" %% "play-specs2"            % Version.play           % "test"
   val specs2        = "org.specs2"        %% "specs2-core"            % Version.specs2         % "test"
 }
@@ -36,9 +29,7 @@ object Dependencies {
     playJson,
     scalaz,
     specs2,
-    guava,
-    jtoValidationCore,
-    jtoValidationJson
+    guava
   )
 }
 
@@ -50,8 +41,6 @@ object Build extends Build {
     "Typesafe repository"           at "http://repo.typesafe.com/typesafe/releases/",
     "Sonatype OSS Snapshots"        at "https://oss.sonatype.org/content/repositories/snapshots",
     "Sonatype OSS Releases"         at "https://oss.sonatype.org/content/repositories/releases",
-    "Mandubian repository releases" at "https://github.com/mandubian/mandubian-mvn/tree/master/releases",
-    "JTO snapshots"                 at "https://raw.github.com/jto/mvn-repo/master/snapshots",
     "scalaz-bintray"                at "http://dl.bintray.com/scalaz/releases"
   )
 

--- a/src/main/scala/com/eclipsesource/schema/JsonSource.scala
+++ b/src/main/scala/com/eclipsesource/schema/JsonSource.scala
@@ -18,10 +18,4 @@ object JsonSource {
     try source.getLines.mkString("\n") finally source.close
   }.flatMap(fromString)
 
-  def fromFile(filePath: String): Try[JsValue] = Try {
-    val source = Source.fromFile(filePath)
-    try source.getLines.mkString("\n") finally source.close
-  }.flatMap(fromString)
-
-
 }

--- a/src/main/scala/com/eclipsesource/schema/internal/Context.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/Context.scala
@@ -3,7 +3,7 @@ package com.eclipsesource.schema.internal
 import java.net.URI
 
 import com.eclipsesource.schema.{RefAttribute, SchemaType}
-import play.api.data.mapping.Path
+import play.api.libs.json.JsPath
 
 import scala.util.Try
 
@@ -12,8 +12,8 @@ case class Context(
                     documentRoot: SchemaType,
                     id: Option[String] = None,     // current resolution scope
                     rootId: Option[String] = None, // base URI
-                    schemaPath: Path = Path("#"),
-                    instancePath: Path = Path(),
+                    schemaPath: JsPath = JsPath \ "#",
+                    instancePath: JsPath = JsPath,
                     visited: Set[RefAttribute] = Set.empty // tracks all visited refs
 ) {
   def isRootScope = {

--- a/src/main/scala/com/eclipsesource/schema/internal/RefResolver.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/RefResolver.scala
@@ -4,8 +4,7 @@ import java.net.{URI, URL, URLDecoder}
 
 import com.eclipsesource.schema._
 
-import play.api.data.mapping.Path
-import play.api.libs.json.Json
+import play.api.libs.json.{JsPath, Json}
 
 import scala.io.{BufferedSource, Source}
 import scala.util.Try
@@ -140,8 +139,8 @@ object RefResolver {
           resolved <- resolvable.resolvePath(fragment)
           res <- resolveFragments(rest,
             context.copy(
-              schemaPath = context.schemaPath.compose(Path(fragment)),
-              instancePath = context.instancePath.compose(Path(fragment))
+              schemaPath = context.schemaPath.compose(JsPath \ fragment),
+              instancePath = context.instancePath.compose(JsPath \ fragment)
             ),
             resolved
           )

--- a/src/main/scala/com/eclipsesource/schema/internal/Results.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/Results.scala
@@ -1,8 +1,10 @@
 package com.eclipsesource.schema.internal
 
-import play.api.data.mapping._
+import com.eclipsesource.schema.internal.validation.VA
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
+
+import scalaz.{Failure, Success}
 
 object Results {
 
@@ -10,7 +12,7 @@ object Results {
     (va1, va2) match {
       case (Success(_), f@Failure(err)) => f
       case (f@Failure(_), Success(_)) => f
-      case (f1@Failure(errs1), f2@Failure(errs2)) => Failure(errs1 ++ errs2)
+      case (f1@Failure(errs1), f2@Failure(errs2))    => Failure(errs1 ++ errs2)
       case (s@Success(obj1@JsObject(_)), Success(_)) => s
       case (s@Success(JsArray(values1)), Success(_)) => s
       case (s@Success(json), Success(_)) => s
@@ -31,8 +33,8 @@ object Results {
   }
 
   def failureWithPath(msg: String,
-                      schemaPath: Path,
-                      instancePath: Path,
+                      schemaPath: JsPath,
+                      instancePath: JsPath,
                       instance: JsValue,
                      additionalInfo: JsObject = Json.obj()): VA[JsValue] = {
     Failure(Seq(instancePath ->

--- a/src/main/scala/com/eclipsesource/schema/internal/SchemaUtil.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/SchemaUtil.scala
@@ -1,7 +1,7 @@
 package com.eclipsesource.schema.internal
 
 import com.eclipsesource.schema.{SchemaArray, SchemaObject, SchemaType}
-import play.api.data.mapping.{Path, ValidationError}
+import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
 object SchemaUtil {
@@ -27,7 +27,7 @@ object SchemaUtil {
     }
   }
 
-  def toJson(errors:  Seq[(Path, Seq[ValidationError])]): JsArray = {
+  def toJson(errors:  Seq[(JsPath, Seq[ValidationError])]): JsArray = {
     val emptyErrors = Json.arr()
     errors.foldLeft(emptyErrors) { case (accumulatedErrors, (path, validationErrors)) =>
       val maybeError = validationErrors.foldLeft(None: Option[JsObject])((aggregatedError, err) => err.args.headOption match {

--- a/src/main/scala/com/eclipsesource/schema/internal/package.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/package.scala
@@ -1,10 +1,11 @@
 package com.eclipsesource.schema
 
-import play.api.data.mapping.{VA}
+import com.eclipsesource.schema.internal.validation.VA
 import play.api.libs.json._
 
-import scala.util.{Try, Success, Failure}
-import scalaz._
+import scalaz.{ReaderWriterState, Semigroup}
+
+
 
 package object internal {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validation/Rule.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validation/Rule.scala
@@ -1,0 +1,182 @@
+package com.eclipsesource.schema.internal.validation
+
+import play.api.data.validation.ValidationError
+import play.api.libs.json.JsPath
+
+import scalaz.{Failure, Success}
+
+trait RuleLike[I, O] {
+  /**
+    * Apply the Rule to `data`
+    *
+    * @param data The data to validate
+    * @return The Result of validating the data
+    */
+  def validate(data: I): VA[O]
+}
+
+/**
+  * A Rule is
+  */
+trait Rule[I, O] extends RuleLike[I, O] {
+
+//  /**
+//    * Compose two Rules
+//    * {{{
+//    *   val r1: Rule[JsValue, String] = // implementation
+//    *   val r2: Rule[String, Date] = // implementation
+//    *   val r = r1.compose(r2)
+//    *
+//    * }}}
+//    *
+//    * @param path a prefix for the errors path if the result is a `Failure`
+//    * @param sub the second Rule to apply
+//    * @return The combination of the two Rules
+//    */
+//  def compose[P](path: Path)(sub: => RuleLike[O, P]): Rule[I, P] =
+//    this.flatMap { o => Rule(_ => sub.validate(o)) }.repath(path ++ _)
+
+//  def flatMap[B](f: O => Rule[I, B]): Rule[I, B] =
+//    Rule { d =>
+//      this.validate(d)
+//        .map(f)
+//        .fold(
+//          es => Failure(es),
+//          r => r.validate(d))
+//    }
+
+//  /**
+//    * Create a new Rule that try `this` Rule, and apply `t` if it fails
+//    * {{{
+//    *   val rb: Rule[JsValue, A] = From[JsValue]{ __ =>
+//    *     ((__ \ "name").read[String] ~ (__ \ "foo").read[Int])(B.apply _)
+//    *   }
+//    *
+//    *   val rc: Rule[JsValue, A] = From[JsValue]{ __ =>
+//    *     ((__ \ "name").read[String] ~ (__ \ "bar").read[Int])(C.apply _)
+//    *   }
+//    *   val rule = rb orElse rc orElse Rule(_ => typeFailure)
+//    * }}}
+//    *
+//    * @param t an alternative Rule
+//    * @return a Rule
+//    */
+//  def orElse[OO >: O](t: => RuleLike[I, OO]): Rule[I, OO] =
+//    Rule(d => this.validate(d) orElse t.validate(d))
+
+  // would be nice to have Kleisli in play
+//  def compose[P](sub: => RuleLike[O, P]): Rule[I, P] = compose(Path)(sub)
+//  def compose[P](m: Mapping[ValidationError, O, P]): Rule[I, P] = compose(Rule.fromMapping(m))
+
+  /**
+    * Create a new Rule the validate `this` Rule and `r2` simultaneously
+    * If `this` and `r2` both fail, all the error are returned
+    * {{{
+    *   val valid = Json.obj(
+    *      "firstname" -> "Julien",
+    *      "lastname" -> "Tournay")
+    *   val composed = notEmpty |+| minLength(3)
+    *   (Path \ "firstname").read(composed).validate(valid) // Success("Julien")
+    *  }}}
+    */
+  def |+|[OO <: O](r2: RuleLike[I, OO]): Rule[I, O] = Rule[I, O] { v =>
+    Rule.keepAnd(this.validate(v), r2.validate(v)).leftMap {
+      _.groupBy(_._1).map {
+        case (path, errs) =>
+          path -> errs.flatMap(_._2)
+      }.toSeq
+    }
+  }
+  /**
+    * This methods allows you to modify the Path of errors (if the result is a Failure) when aplying the Rule
+    */
+  def repath(f: JsPath => JsPath): Rule[I, O] =
+    Rule { d =>
+      this.validate(d).leftMap {
+        _.map {
+          case (p, errs) => f(p) -> errs
+        }
+      }
+    }
+
+}
+
+object Rule {
+  import scala.language.experimental.macros
+
+//  def gen[I, O]: Rule[I, O] = macro MappingMacros.rule[I, O]
+
+  // TODO: rename (keepAnd ?)
+  def keepAnd[E, EE >: E, A, B](a: Validated[E, A], o: Validated[E, B]): Validated[EE, B] = (a, o) match {
+    case (Success(_), Success(v)) => Success(v)
+    case (Success(_), Failure(e)) => Failure(e)
+    case (Failure(e), Success(_)) => Failure(e)
+    case (Failure(e1), Failure(e2)) => Failure(e1 ++ e2)
+  }
+
+//  def viaEither[E, A, EE, AA](v: Validated[E, A], f: Either[Seq[E], A] => Either[Seq[EE], AA]): Validated[EE, AA] =
+//    f(v.toEither).fold(Failure.apply, Success.apply)
+
+//  def viaEither[EE, AA](f: Either[Seq[E], A] => Either[Seq[EE], AA]): Validation[EE, AA] =
+//    f(asEither).fold(Failure.apply, Success.apply)
+
+  /**
+    * Turn a `A => Rule[B, C]` into a `Rule[(A, B), C]`
+    * {{{
+    *   val passRule = From[JsValue] { __ =>
+    *      ((__ \ "password").read(notEmpty) ~ (__ \ "verify").read(notEmpty))
+    *        .tupled.compose(Rule.uncurry(Rules.equalTo[String]).repath(_ => (Path \ "verify")))
+    *    }
+    * }}}
+    */
+//  def uncurry[A, B, C](f: A => Rule[B, C]): Rule[(A, B), C] =
+//    Rule { case (a, b) => f(a).validate(b) }
+
+//  import play.api.libs.functional._
+
+//  implicit def zero[O] = toRule(RuleLike.zero[O])
+
+  def apply[I, O](m: Mapping[(JsPath, Seq[ValidationError]), I, O]) = new Rule[I, O] {
+    def validate(data: I): VA[O] = m(data)
+  }
+
+//  def toRule[I, O](r: RuleLike[I, O]) = new Rule[I, O] {
+//    def validate(data: I): VA[O] = r.validate(data)
+//  }
+
+  def fromMapping[I, O](f: Mapping[ValidationError, I, O]): Rule[I, O] =
+    Rule[I, O](f(_: I).leftMap(errs => Seq(JsPath -> errs)))
+
+//  implicit def applicativeRule[I] = new Applicative[({ type λ[O] = Rule[I, O] })#λ] {
+//    override def pure[A](a: A): Rule[I, A] =
+//      Rule(_ => Success(a))
+//
+//    override def map[A, B](m: Rule[I, A], f: A => B): Rule[I, B] =
+//      Rule(d => m.validate(d).map(f))
+
+//    override def apply[A, B](mf: Rule[I, A => B], ma: Rule[I, A]): Rule[I, B] =
+//      Rule { d =>
+//        val a: VA[A] = ma.validate(d)
+//        val f: VA[A => B] = mf.validate(d)
+//        val keep: Validated[(Path, Seq[ValidationError]), A] = keepAnd(f, a)
+//        viaEither[(Path, Seq[ValidationError]), A, (Path, Seq[ValidationError]), B](keep, e => e.right.flatMap(x => {
+//          val ei: Either[Seq[(Path, Seq[ValidationError])], (A) => B] = f.toEither
+//          ei.right.map(y => y(x))
+//        }))
+//      }
+//  }
+
+//  implicit def functorRule[I] = new Functor[({ type λ[O] = Rule[I, O] })#λ] {
+//    def fmap[A, B](m: Rule[I, A], f: A => B): Rule[I, B] = applicativeRule[I].map(m, f)
+//  }
+
+//  implicit def functorExtractorRule[I, O]: VariantExtractor[({ type λ[O] = Rule[I, O] })#λ] =
+//    VariantExtractor.functor[({ type λ[O] = Rule[I, O] })#λ](functorRule)
+
+  // XXX: Helps the compiler a bit
+//  import play.api.libs.functional.syntax._
+//  implicit def cba[I] = functionalCanBuildApplicative[({ type λ[O] = Rule[I, O] })#λ]
+//  implicit def fbo[I, O] = toFunctionalBuilderOps[({ type λ[O] = Rule[I, O] })#λ, O] _
+//  implicit def ao[I, O] = toApplicativeOps[({ type λ[O] = Rule[I, O] })#λ, O] _
+//  implicit def f[I, O] = toFunctorOps[({ type λ[O] = Rule[I, O] })#λ, O] _
+}

--- a/src/main/scala/com/eclipsesource/schema/internal/validation/package.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validation/package.scala
@@ -1,0 +1,12 @@
+package com.eclipsesource.schema.internal
+
+import play.api.data.validation.ValidationError
+import play.api.libs.json.{JsPath}
+import scalaz.{Validation}
+
+package object validation {
+  type Validated[E, O] = Validation[Seq[E], O]
+  type Mapping[E, I, O] = I => Validated[E, O]
+  type Constraint[T] = Mapping[ValidationError, T, T]
+  type VA[O] = Validated[(JsPath, Seq[ValidationError]), O]
+}

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/AnyConstraintValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/AnyConstraintValidator.scala
@@ -3,8 +3,10 @@ package com.eclipsesource.schema.internal.validators
 import com.eclipsesource.schema.SchemaValidator
 import com.eclipsesource.schema.internal._
 import com.eclipsesource.schema.internal.constraints.Constraints.AnyConstraint
-import play.api.data.mapping._
+import com.eclipsesource.schema.internal.validation.{VA, Rule}
 import play.api.libs.json._
+
+import scalaz.{Failure, Success}
 
 object AnyConstraintValidator {
 
@@ -23,7 +25,7 @@ object AnyConstraintValidator {
     scalaz.Reader { case (any ,context) =>
       Rule.fromMapping { json =>
         any.not.map(schema =>
-          if (SchemaValidator.validate(schema, json).isFailure) {
+          if (SchemaValidator.validate(schema, json).isError) {
             Success(json)
           } else {
             failure(

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayConstraintValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayConstraintValidator.scala
@@ -1,9 +1,11 @@
 package com.eclipsesource.schema.internal.validators
 
 import com.eclipsesource.schema.internal.constraints.Constraints.ArrayConstraints
-import com.eclipsesource.schema.internal.{Context, Results, SchemaUtil}
-import play.api.data.mapping.{Rule, Success, VA}
+import com.eclipsesource.schema.internal.validation.{VA, Rule}
+import com.eclipsesource.schema.internal.{Context, SchemaUtil}
 import play.api.libs.json.{JsArray, JsValue}
+
+import scalaz.Success
 
 trait ArrayConstraintValidator {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayValidator.scala
@@ -1,9 +1,11 @@
 package com.eclipsesource.schema.internal.validators
 
+import com.eclipsesource.schema.internal.validation.VA
 import com.eclipsesource.schema.internal.{Context, Results, SchemaUtil}
 import com.eclipsesource.schema.{SchemaArray, SchemaValidator}
-import play.api.data.mapping.{Failure, Success, VA}
 import play.api.libs.json.{JsArray, JsValue}
+
+import scalaz.{Success, Failure}
 
 
 object ArrayValidator extends SchemaTypeValidator[SchemaArray] with ArrayConstraintValidator {

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/CompoundValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/CompoundValidator.scala
@@ -1,15 +1,22 @@
 package com.eclipsesource.schema.internal.validators
 import com.eclipsesource.schema._
 import com.eclipsesource.schema.CompoundSchemaType
+import com.eclipsesource.schema.internal.validation.VA
 import com.eclipsesource.schema.internal.{Context, Results}
-import play.api.data.mapping.VA
-import play.api.libs.json.JsValue
+import play.api.libs.json.{JsError, JsSuccess, JsValue}
+
+import scalaz.{Failure, Success}
 
 object CompoundValidator extends SchemaTypeValidator[CompoundSchemaType] {
   override def validate(schema: CompoundSchemaType, json: => JsValue, context: Context): VA[JsValue] = {
-    schema.alternatives
-      .map(s => SchemaValidator.validate(s, json))
-      .find(_.isSuccess)
+    val result: Option[VA[JsValue]] = schema.alternatives
+      .map(s =>
+        SchemaValidator.validate(s, json) match {
+          case JsSuccess(success, _) => Success(success)
+          case JsError(errors) => Failure(errors)
+        }
+      ).find(_.isSuccess)
+    result
       .getOrElse(
         Results.failureWithPath(
           "No schema applied",

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/IntegerValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/IntegerValidator.scala
@@ -2,10 +2,11 @@ package com.eclipsesource.schema.internal.validators
 
 import com.eclipsesource.schema.SchemaInteger
 import com.eclipsesource.schema.internal.constraints.Constraints.NumberConstraints
-import com.eclipsesource.schema.internal.{SchemaUtil, Results, Context}
-import play.api.data.mapping.{Failure, Rule, Success, VA}
-import play.api.data.validation.ValidationError
-import play.api.libs.json.{Json, JsNumber, JsValue}
+import com.eclipsesource.schema.internal.validation.{Rule, VA}
+import com.eclipsesource.schema.internal.{SchemaUtil, Context}
+import play.api.libs.json.{JsNumber, JsValue}
+
+import scalaz.Success
 
 object IntegerValidator extends SchemaTypeValidator[SchemaInteger] with NumberConstraintsValidator {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/NumberConstraintsValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/NumberConstraintsValidator.scala
@@ -1,9 +1,11 @@
 package com.eclipsesource.schema.internal.validators
 
+import com.eclipsesource.schema.internal.validation.Rule
 import com.eclipsesource.schema.internal.{Context, SchemaUtil}
 import com.eclipsesource.schema.internal.constraints.Constraints.{Maximum, Minimum, NumberConstraints}
-import play.api.data.mapping.{Rule, Success}
 import play.api.libs.json.{JsNumber, JsValue}
+
+import scalaz.Success
 
 trait NumberConstraintsValidator {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/NumberValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/NumberValidator.scala
@@ -2,7 +2,7 @@ package com.eclipsesource.schema.internal.validators
 
 import com.eclipsesource.schema.SchemaNumber
 import com.eclipsesource.schema.internal.Context
-import play.api.data.mapping.VA
+import com.eclipsesource.schema.internal.validation.VA
 import play.api.libs.json.JsValue
 
 object NumberValidator extends SchemaTypeValidator[SchemaNumber] with NumberConstraintsValidator {

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ObjectValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ObjectValidator.scala
@@ -3,9 +3,9 @@ package com.eclipsesource.schema.internal.validators
 import java.util.regex.Pattern
 import com.eclipsesource.schema._
 import com.eclipsesource.schema.internal._
-import play.api.data.mapping._
+import com.eclipsesource.schema.internal.validation.VA
 import play.api.libs.json._
-import scalaz.ReaderWriterState
+import scalaz.{Success, ReaderWriterState}
 
 object ObjectValidator extends SchemaTypeValidator[SchemaObject] {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/StringValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/StringValidator.scala
@@ -6,8 +6,10 @@ import java.util.regex.Pattern
 import com.eclipsesource.schema.SchemaString
 import com.eclipsesource.schema.internal.constraints.Constraints.StringConstraints
 import com.eclipsesource.schema.internal.Context
-import play.api.data.mapping.{Rule, Success, VA}
+import com.eclipsesource.schema.internal.validation.{VA, Rule}
 import play.api.libs.json.{JsString, JsValue}
+
+import scalaz.Success
 
 object StringValidator extends SchemaTypeValidator[SchemaString] {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/TupleValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/TupleValidator.scala
@@ -1,9 +1,11 @@
 package com.eclipsesource.schema.internal.validators
 
 import com.eclipsesource.schema._
+import com.eclipsesource.schema.internal.validation.VA
 import com.eclipsesource.schema.internal.{Context, Results}
-import play.api.data.mapping.{Failure, Success, VA}
 import play.api.libs.json.{JsBoolean, JsArray, JsValue}
+
+import scalaz.{Success, Failure}
 
 object TupleValidator extends SchemaTypeValidator[SchemaTuple] with ArrayConstraintValidator {
 

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/Validator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/Validator.scala
@@ -1,7 +1,7 @@
 package com.eclipsesource.schema.internal.validators
 
-import com.eclipsesource.schema.internal.{Context}
-import play.api.data.mapping.VA
+import com.eclipsesource.schema.internal.validation.VA
+import com.eclipsesource.schema.internal.Context
 import play.api.libs.json.JsValue
 
 trait SchemaTypeValidator[S] {

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/package.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/package.scala
@@ -1,30 +1,31 @@
 package com.eclipsesource.schema.internal
 
-import play.api.data.mapping.{Failure, Path, Validation}
+import com.eclipsesource.schema.internal.validation.{Validated}
 import play.api.data.validation.ValidationError
-import play.api.libs.json.{JsObject, JsValue, Json}
+import play.api.libs.json.{JsPath, JsObject, JsValue, Json}
+import scalaz.Failure
 
 package object validators {
 
   implicit val objectValidator = ObjectValidator
 
   def failure(msg: String,
-              schemaPath: Path,
-              instancePath: Path,
+              schemaPath: JsPath,
+              instancePath: JsPath,
               instance: JsValue,
               additionalInfo: JsObject = Json.obj()
-             ): Validation[ValidationError, JsValue] = {
+             ): Validated[ValidationError, JsValue] = {
     def dropSlashIfAny(path: String) = if (path.startsWith("/#")) path.substring(1) else path
     Failure(
       Seq(
-        ValidationError(msg,
-          Json.obj(
-            "schemaPath" -> dropSlashIfAny(schemaPath.toString()),
-            "instancePath" -> instancePath.toString(),
-            "value" -> instance,
-            "errors" ->  additionalInfo
-          )
+      ValidationError(msg,
+        Json.obj(
+          "schemaPath" -> dropSlashIfAny(schemaPath.toString()),
+          "instancePath" -> instancePath.toString(),
+          "value" -> instance,
+          "errors" ->  additionalInfo
         )
+      )
       )
     )
   }

--- a/src/main/scala/com/eclipsesource/schema/package.scala
+++ b/src/main/scala/com/eclipsesource/schema/package.scala
@@ -1,13 +1,12 @@
 package com.eclipsesource
 
+import com.eclipsesource.schema.internal.validation.VA
 import com.eclipsesource.schema.internal.validators._
 import com.eclipsesource.schema.internal.{Results, Context, SchemaUtil}
 import com.eclipsesource.schema.internal.serialization.{JSONSchemaReads, JSONSchemaWrites}
-import play.api.data.mapping.{Path, Success, VA}
 import play.api.data.validation.ValidationError
 import play.api.libs.json._
-
-import scalaz.{Failure => _, Success => _}
+import scalaz.Success
 
 package object schema
   extends SchemaOps
@@ -40,7 +39,7 @@ package object schema
     }
   }
 
-  implicit class FailureExtensions(errors: Seq[(Path, Seq[ValidationError])]) {
+  implicit class FailureExtensions(errors: Seq[(JsPath, Seq[ValidationError])]) {
     def toJson: JsArray = SchemaUtil.toJson(errors)
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/ErrorReportingSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/ErrorReportingSpec.scala
@@ -1,7 +1,8 @@
 package com.eclipsesource.schema
 
+import com.eclipsesource.schema.internal.validation.VA
 import org.specs2.mutable.Specification
-import play.api.data.mapping.{ValidationError, Path, VA}
+import play.api.data.validation.ValidationError
 import play.api.libs.json._
 
 class ErrorReportingSpec extends Specification {
@@ -18,8 +19,8 @@ class ErrorReportingSpec extends Specification {
           |  "title": { "type": "string", "minLength": 3, "pattern": "^[A-Z].*" }
           |}
           |}""".stripMargin).get
-      val result: VA[JsValue] = SchemaValidator.validate(schema)(Json.obj("title" -> "a"))
-      result.isFailure must beTrue
+      val result: JsResult[JsValue] = SchemaValidator.validate(schema)(Json.obj("title" -> "a"))
+      result.isError must beTrue
       result.asEither must beLeft.like { case error => (error.toJson(0) \ "msgs").get.as[JsArray].value.size == 2 }
     }
 
@@ -33,8 +34,8 @@ class ErrorReportingSpec extends Specification {
           |},
           |"required": ["foo", "bar"]
           |}""".stripMargin).get
-      val result: VA[JsValue] = SchemaValidator.validate(schema)(Json.obj())
-      result.isFailure must beTrue
+      val result: JsResult[JsValue] = SchemaValidator.validate(schema)(Json.obj())
+      result.isError must beTrue
       result.asEither must beLeft.like { case error => error.toJson.as[JsArray].value.size == 2 }
     }
 
@@ -54,10 +55,10 @@ class ErrorReportingSpec extends Specification {
           |},
           |"required": ["foo", "bar"]
           |}""".stripMargin).get
-      val result: VA[JsValue] = SchemaValidator.validate(schema)(Json.obj("bar" -> Json.obj()))
-      result.isFailure must beTrue
+      val result: JsResult[JsValue] = SchemaValidator.validate(schema)(Json.obj("bar" -> Json.obj()))
+      result.isError must beTrue
       result.asEither must beLeft.like { case error =>
-        error.toJson.value.size == 2
+        error.toJson.value must haveLength(2)
       }
     }
   }
@@ -71,12 +72,12 @@ class ErrorReportingSpec extends Specification {
         |  ]
         |}""".stripMargin).get
 
-    val result: VA[JsValue] = SchemaValidator.validate(schema)(JsNumber(1.5))
-    val failure: Seq[(Path, Seq[ValidationError])] = result.asEither.left.get
+    val result: JsResult[JsValue] = SchemaValidator.validate(schema)(JsNumber(1.5))
+    val failure: Seq[(JsPath, Seq[ValidationError])] = result.asEither.left.get
     val failureJson = failure.toJson
     val JsDefined(subErrors) = failureJson(0) \ "errors"
 
-    result.isFailure must beTrue
+    result.isError must beTrue
     failureJson(0) \ "schemaPath" must beEqualTo(JsDefined(JsString("#")))
     subErrors.as[JsObject].keys must haveSize(2)
     (subErrors.as[JsObject] \ "/anyOf/1").as[JsArray].value.head \ "schemaPath" must beEqualTo(
@@ -100,8 +101,8 @@ class ErrorReportingSpec extends Specification {
         |  }
         |}
         |}""".stripMargin).get
-    val result: VA[JsValue] = SchemaValidator.validate(schema)(Json.obj("foo" -> 1.5))
-    result.isFailure must beTrue
+    val result: JsResult[JsValue] = SchemaValidator.validate(schema)(Json.obj("foo" -> 1.5))
+    result.isError must beTrue
     result.asEither must beLeft.like { case error =>
       error.toJson(0) \ "schemaPath" == JsDefined(JsString("#/properties/foo"))
     }
@@ -126,7 +127,7 @@ class ErrorReportingSpec extends Specification {
         |]
         |}""".stripMargin).get
     val result = SchemaValidator.validate(schema)(Json.obj("foo" -> "baz"))
-    result.isFailure must beTrue
+    result.isError must beTrue
     result.asEither must beLeft.like { case error =>
       error.toJson(0) \ "msgs" == JsDefined(JsArray(Seq(JsString("Instance does not match all schemas"))))
     }
@@ -147,8 +148,8 @@ class ErrorReportingSpec extends Specification {
         stripMargin).
       get
 
-    val result: VA[JsValue] = SchemaValidator.validate(schema)(JsNumber(3))
-    result.isFailure must beTrue
+    val result: JsResult[JsValue] = SchemaValidator.validate(schema)(JsNumber(3))
+    result.isError must beTrue
     result.asEither must beLeft.like { case error =>
       error.toJson(0) \ "msgs" == JsDefined(JsArray(Seq(JsString("Instance matches more than one schema"))))
     }
@@ -168,8 +169,8 @@ class ErrorReportingSpec extends Specification {
         |}""".
         stripMargin).get
 
-    val result: VA[JsValue] = SchemaValidator.validate(schema)(JsNumber(1.14))
-    result.isFailure must beTrue
+    val result: JsResult[JsValue] = SchemaValidator.validate(schema)(JsNumber(1.14))
+    result.isError must beTrue
     result.asEither must beLeft.like { case error =>
       val JsDefined(obj) = error.toJson(0)
       obj \ "msgs" == JsDefined(JsArray(Seq(JsString("Instance does not match any schema"))))

--- a/src/test/scala/com/eclipsesource/schema/ItemsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/ItemsSpec.scala
@@ -20,7 +20,7 @@ class ItemsSpec extends Specification with JsonSpec {
     val i = Json.arr(2, 3, 4, 1)
 
     val result = SchemaValidator.validate(s)(i)
-    result.isFailure must beTrue
+    result.isError must beTrue
     result.asEither must beLeft.like { case error =>
       error.toJson.value must haveLength(2)
     }

--- a/src/test/scala/com/eclipsesource/schema/MaxLengthSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/MaxLengthSpec.scala
@@ -15,8 +15,10 @@ class MaxLengthSpec extends Specification with JsonSpec {
         }""".stripMargin).get
       val json = JsString("foo")
       val result = SchemaValidator.validate(schema)(json)
-      result.isFailure must beTrue
-      result.asEither must beLeft.like { case error => (error.toJson(0) \ "msgs") == JsDefined(JsArray(Seq(JsString("foo violates max length of 2")))) }
+      result.isError must beTrue
+      result.asEither must beLeft.like {
+        case error => (error.toJson(0) \ "msgs") == JsDefined(JsArray(Seq(JsString("foo violates max length of 2"))))
+      }
     }
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/MinLengthSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/MinLengthSpec.scala
@@ -25,7 +25,7 @@ class MinLengthSpec extends Specification with JsonSpec {
           |"minLength": 3
         }""".stripMargin).get
 
-      SchemaValidator.validate(schema)(JsString("12")).isFailure must beTrue
+      SchemaValidator.validate(schema)(JsString("12")).isError must beTrue
     }
 
   }

--- a/src/test/scala/com/eclipsesource/schema/ResolveRefSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/ResolveRefSpec.scala
@@ -2,8 +2,6 @@ package com.eclipsesource.schema
 
 import com.eclipsesource.schema.internal.{Context, RefResolver}
 import org.specs2.mutable.Specification
-import play.api.data.mapping.Path
-
 
 class ResolveRefSpec extends Specification {
 

--- a/src/test/scala/com/eclipsesource/schema/internal/resolvable/ResolveSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/resolvable/ResolveSpec.scala
@@ -4,7 +4,6 @@ import com.eclipsesource.schema.internal.{GlobalContextCache, RefResolver, Conte
 import com.eclipsesource.schema.{SchemaNull, SchemaValue, SchemaValidator, JsonSource}
 import controllers.Assets
 import org.specs2.mutable.Specification
-import play.api.data.mapping.Path
 import play.api.libs.json._
 import play.api.mvc.Handler
 import play.api.test.{FakeApplication, WithServer}
@@ -254,10 +253,13 @@ class ResolveSpec extends Specification {
             |}""".
             stripMargin).get
 
-        val result = SchemaValidator.validate(schema, Json.obj("foo" -> JsNumber(2015)))
-        result.isSuccess must beTrue
-        val result2 = SchemaValidator.validate(schema, Json.obj("foo" -> JsString("foo")))
-        result2.isFailure must beTrue
+        SchemaValidator.validate(schema,
+          Json.obj("foo" -> JsNumber(2015))
+        ).isSuccess must beTrue
+
+        SchemaValidator.validate(schema,
+          Json.obj("foo" -> JsString("foo"))
+        ).isError must beTrue
       }
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/internal/serialization/SchemaWritesSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/serialization/SchemaWritesSpec.scala
@@ -56,6 +56,13 @@ class SchemaWritesSpec extends Specification {
       ))
     }
 
+    "serialize tuple" in {
+      Json.toJson(SchemaTuple(Seq(SchemaNumber()))) must beEqualTo(Json.obj(
+        "type" -> "array",
+        "items" -> Json.arr(Json.obj("type" -> "number"))
+      ))
+    }
+
     "serialize $ref" in {
       Json.toJson(SchemaObject(Seq(RefAttribute("#", isRemote = false)))) must beEqualTo(Json.obj(
         "type" -> "object",

--- a/src/test/scala/com/eclipsesource/schema/jsonforms/JsonFormsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/jsonforms/JsonFormsSpec.scala
@@ -1,8 +1,8 @@
 package com.eclipsesource.schema.jsonforms
 
 import com.eclipsesource.schema._
+import com.eclipsesource.schema.internal.validation.VA
 import org.specs2.mutable.Specification
-import play.api.data.mapping.VA
 import play.api.libs.json._
 
 class JsonFormsSpec extends Specification {
@@ -133,8 +133,8 @@ class JsonFormsSpec extends Specification {
                               |}]
                               |}""".stripMargin)
 
-      val result: VA[JsValue] = SchemaValidator.validate(jsonFormSchema, json)
-      result.isFailure must beTrue
+      val result: JsResult[JsValue] = SchemaValidator.validate(jsonFormSchema, json)
+      result.isError must beTrue
       result.asEither must beLeft.like { case error =>
         val JsDefined(subErrors) = error.toJson(0) \ "errors"
         subErrors.as[JsObject].keys.size == 3

--- a/src/test/scala/com/eclipsesource/schema/test/JsonSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/test/JsonSpec.scala
@@ -5,16 +5,15 @@ import java.net.URL
 import com.eclipsesource.schema._
 import org.specs2._
 import execute._
-import matcher._
+import play.api.data.validation.ValidationError
 import specification.core._
-import org.specs2.specification.dsl.mutable.{FragmentBuilder}
-import play.api.data.mapping.{Path, ValidationError}
+import org.specs2.specification.dsl.mutable.FragmentBuilder
 import play.api.libs.json._
 import play.api.libs.functional.syntax._
 
 case class JsonSchemaSpec(description: String, schema: SchemaType, tests: Seq[JsonSchemaTest])
 case class JsonSchemaTest(description: String, data: JsValue, valid: Boolean)
-case class SpecResult(description: String, valid: Boolean, error: Option[Seq[(Path, Seq[ValidationError])]])
+case class SpecResult(description: String, valid: Boolean, error: Option[Seq[(JsPath, Seq[ValidationError])]])
 
 trait JsonSpec extends FragmentBuilder {
 
@@ -54,13 +53,6 @@ trait JsonSpec extends FragmentBuilder {
       case JsArray(specs) => Right(executeSpecs(specs))
       case json =>
         Left(s"URL $url does not contain any specs or has wrong format. See https://github.com/json-schema/JSON-Schema-Test-Suite for correct format")
-    }
-  }
-
-  def fromFile(filePath: String): Either[String, Seq[(String, Seq[SpecResult])]] = {
-    JsonSource.fromFile(filePath).getOrElse(Failure(s"Could not read JSON from $filePath.")) match {
-      case JsArray(specs) => Right(executeSpecs(specs))
-      case json => Left(s"File $filePath does not contain any specs or has wrong format. See https://github.com/json-schema/JSON-Schema-Test-Suite for correct format.")
     }
   }
 


### PR DESCRIPTION
Uses Scalaz `Validation` internally while `JsResult` is exposed on API level.