### PR TITLE
Fix for issue #84: Validator tolerates unknown formats

### DIFF
--- a/src/main/resources/messages.txt
+++ b/src/main/resources/messages.txt
@@ -14,7 +14,6 @@ str.pattern          = ''{0}'' does not match pattern {1}.
 str.min.length       = ''{0}'' does not match minimum length of {1}.
 str.max.length       = ''{0}'' exceeds maximum length of {1}.
 str.format           = ''{0}'' does not match format {1}.
-str.unknown.format   = Unknown format ''{0}''.
 
 num.multiple.of      = {0} is not a multiple of {1}.
 num.max              = {0} exceeds maximum value of {1}.

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/StringValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/StringValidator.scala
@@ -118,22 +118,12 @@ object StringValidator extends SchemaTypeValidator[SchemaString] {
                   json
                 )
               }
-            // unknown format
-            case None => unknownFormat(json, context, constraints.format.getOrElse(""))
+            // validation of unknown format should succeed
+            case None => Success(json)
           }
         case json@JsString(_) => Success(json)
       }
     }
-
-  private def unknownFormat(json: JsValue, context: SchemaResolutionContext, format: String)
-                           (implicit lang: Lang) =
-    failure(
-      Keywords.String.Format,
-      Messages("str.unknown.format", format),
-      context.schemaPath,
-      context.instancePath,
-      json
-    )
 
   private def lengthOf(text: String, locale: java.util.Locale = java.util.Locale.ENGLISH): Int = {
     val charIterator = java.text.BreakIterator.getCharacterInstance(locale)

--- a/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
@@ -9,16 +9,13 @@ class FormatSpec extends Specification with JsonSpec {
   validate("optional/format")
 
   "Format" should {
-    "not validate unknown format" in {
-      val formatName = "unknown"
+
+    "validate unknown format" in {
       val schema = JsonSource.schemaFromString(
-        s"""{"format": "$formatName"}"""
+        s"""{"format": "unknown"}"""
       ).get
       val result = SchemaValidator().validate(schema, JsString("some string"))
-      result.asEither must beLeft.like { case error =>
-        val JsDefined(obj) = error.toJson(0)
-        obj \ "msgs" == JsDefined(JsArray(Seq(JsString(s"Unknown format '$formatName'."))))
-      }
+      result.isSuccess must beTrue
     }
 
     "validate UUIDs" in {


### PR DESCRIPTION
Validation of unknown formats succeeds as outlined in http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.1