### PR TITLE
Fix for issue #93: format support for integer type

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/internal/validators/IntegerValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/IntegerValidator.scala
@@ -33,8 +33,9 @@ object IntegerValidator extends SchemaTypeValidator[SchemaInteger] with NumberCo
       maxRule <- validateMax
       minRule <- validateMin
       multipleOfRule <- validateMultipleOf
+      format <- validateFormat
       intRule <- isInt
-    } yield maxRule |+| minRule |+| multipleOfRule |+| intRule
+    } yield maxRule |+| minRule |+| multipleOfRule |+| format |+| intRule
     reader.run((schema.constraints, context)).repath(_.compose(context.instancePath)).validate(json)
   }
 }

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/NumberValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/NumberValidator.scala
@@ -23,35 +23,4 @@ object NumberValidator extends SchemaTypeValidator[SchemaNumber] with NumberCons
       .repath(_.compose(context.instancePath))
       .validate(json)
   }
-
-  def validateFormat(implicit lang: Lang): scalaz.Reader[(NumberConstraints, SchemaResolutionContext), Rule[JsValue, JsValue]] =
-    scalaz.Reader { case (constraints, context) =>
-
-      val format = for {
-        formatName <- constraints.format
-        f <- context.formats.get(formatName)
-      } yield f
-
-      Rule.fromMapping {
-        case json@JsNumber(number) if constraints.format.isDefined =>
-          format match {
-            // format found
-            case Some(f) =>
-              if (f.validate(json)) {
-                Success(json)
-              } else {
-                failure(
-                  Keywords.String.Format,
-                  Messages("str.format", number, f.name),
-                  context.schemaPath,
-                  context.instancePath,
-                  json
-                )
-              }
-            // validation of unknown format should succeed
-            case None => Success(json)
-          }
-        case json@JsNumber(_) => Success(json)
-      }
-    }
 }

--- a/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
@@ -78,11 +78,13 @@ class FormatSpec extends Specification with JsonSpec {
           | }
         """.stripMargin).get
 
-      validator.validate(integerSchema, JsNumber(Integer.MAX_VALUE)).isSuccess must beTrue
-      validator.validate(integerSchema, JsNumber(BigDecimal.valueOf(Integer.MAX_VALUE) + 1)).isError must beTrue
+      validator.validate(integerSchema, JsNumber(Int.MinValue)).isSuccess must beTrue
+      validator.validate(integerSchema, JsNumber(Int.MaxValue)).isSuccess must beTrue
+      validator.validate(integerSchema, JsNumber(BigDecimal.valueOf(Int.MaxValue) + 1)).isError must beTrue
 
-      validator.validate(numberSchema, JsNumber(Integer.MAX_VALUE)).isSuccess must beTrue
-      validator.validate(numberSchema, JsNumber(BigDecimal.valueOf(Integer.MAX_VALUE) + 1)).isError must beTrue
+      validator.validate(numberSchema, JsNumber(Int.MinValue)).isSuccess must beTrue
+      validator.validate(numberSchema, JsNumber(Int.MaxValue)).isSuccess must beTrue
+      validator.validate(numberSchema, JsNumber(BigDecimal.valueOf(Int.MaxValue) + 1)).isError must beTrue
     }
 
 
@@ -102,8 +104,11 @@ class FormatSpec extends Specification with JsonSpec {
           | }
         """.stripMargin).get
 
+      validator.validate(integerSchema, JsNumber(Long.MinValue)).isSuccess must beTrue
       validator.validate(integerSchema, JsNumber(Long.MaxValue)).isSuccess must beTrue
       validator.validate(integerSchema, JsNumber(BigDecimal.valueOf(Long.MaxValue) + 1)).isError must beTrue
+
+      validator.validate(numberSchema, JsNumber(Long.MinValue)).isSuccess must beTrue
       validator.validate(numberSchema, JsNumber(Long.MaxValue)).isSuccess must beTrue
       validator.validate(numberSchema, JsNumber(BigDecimal.valueOf(Long.MaxValue) + 1)).isError must beTrue
     }
@@ -140,7 +145,7 @@ class FormatSpec extends Specification with JsonSpec {
       validatorWithRangeFormat.validate(numberSchema, JsNumber(-1)).isError must beTrue
     }
 
-    "validate integer against double max boundary" in {
+    "validate integer with int32 format against double max boundary" in {
       val schema = JsonSource.schemaFromString(
         """
           |{
@@ -157,6 +162,24 @@ class FormatSpec extends Specification with JsonSpec {
         "intprop" -> -1.7976931348623157E+308
       )
       validator.validate(schema, instance).isError must beTrue
+    }
+
+    "validate integer without format against double max boundary" in {
+      val schema = JsonSource.schemaFromString(
+        """
+          |{
+          |  "type" : "object",
+          |  "properties" : {
+          |    "intprop" : {
+          |      "type" : "integer"
+          |    }
+          |  }
+          |}
+        """.stripMargin).get
+      val instance = Json.obj(
+        "intprop" -> -1.7976931348623157E+308
+      )
+      validator.validate(schema, instance).isSuccess must beTrue
     }
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
@@ -139,5 +139,24 @@ class FormatSpec extends Specification with JsonSpec {
       validatorWithRangeFormat.validate(numberSchema, JsNumber(10)).isSuccess must beTrue
       validatorWithRangeFormat.validate(numberSchema, JsNumber(-1)).isError must beTrue
     }
+
+    "validate integer against double max boundary" in {
+      val schema = JsonSource.schemaFromString(
+        """
+          |{
+          |  "type" : "object",
+          |  "properties" : {
+          |    "intprop" : {
+          |      "type" : "integer",
+          |      "format" : "int32"
+          |    }
+          |  }
+          |}
+        """.stripMargin).get
+      val instance = Json.obj(
+        "intprop" -> -1.7976931348623157E+308
+      )
+      validator.validate(schema, instance).isError must beTrue
+    }
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
@@ -63,28 +63,49 @@ class FormatSpec extends Specification with JsonSpec {
     }
 
     "validate int32 format" in {
-      val schema = JsonSource.schemaFromString(
+      val integerSchema = JsonSource.schemaFromString(
+        """
+          |{
+          |  "type": "integer",
+          |  "format": "int32"
+          | }
+        """.stripMargin).get
+      val numberSchema = JsonSource.schemaFromString(
         """
           |{
           |  "type": "number",
           |  "format": "int32"
           | }
         """.stripMargin).get
-      validator.validate(schema, JsNumber(Integer.MAX_VALUE)).isSuccess must beTrue
-      validator.validate(schema, JsNumber(BigDecimal.valueOf(Integer.MAX_VALUE) + 1)).isError must beTrue
+
+      validator.validate(integerSchema, JsNumber(Integer.MAX_VALUE)).isSuccess must beTrue
+      validator.validate(integerSchema, JsNumber(BigDecimal.valueOf(Integer.MAX_VALUE) + 1)).isError must beTrue
+
+      validator.validate(numberSchema, JsNumber(Integer.MAX_VALUE)).isSuccess must beTrue
+      validator.validate(numberSchema, JsNumber(BigDecimal.valueOf(Integer.MAX_VALUE) + 1)).isError must beTrue
     }
 
 
     "validate int64 format" in {
-      val schema = JsonSource.schemaFromString(
+      val numberSchema = JsonSource.schemaFromString(
         """
           |{
           |  "type": "number",
           |  "format": "int64"
           | }
         """.stripMargin).get
-      validator.validate(schema, JsNumber(Long.MaxValue)).isSuccess must beTrue
-      validator.validate(schema, JsNumber(BigDecimal.valueOf(Long.MaxValue) + 1)).isError must beTrue
+      val integerSchema = JsonSource.schemaFromString(
+        """
+          |{
+          |  "type": "integer",
+          |  "format": "int64"
+          | }
+        """.stripMargin).get
+
+      validator.validate(integerSchema, JsNumber(Long.MaxValue)).isSuccess must beTrue
+      validator.validate(integerSchema, JsNumber(BigDecimal.valueOf(Long.MaxValue) + 1)).isError must beTrue
+      validator.validate(numberSchema, JsNumber(Long.MaxValue)).isSuccess must beTrue
+      validator.validate(numberSchema, JsNumber(BigDecimal.valueOf(Long.MaxValue) + 1)).isError must beTrue
     }
 
     "validate custom number range format" in {
@@ -96,15 +117,27 @@ class FormatSpec extends Specification with JsonSpec {
         }
       }
       val validatorWithRangeFormat = validator.addFormat(rangeFormat)
-      val schema = JsonSource.schemaFromString(
+      val numberSchema = JsonSource.schemaFromString(
         """
           |{
           |  "type": "number",
           |  "format": "range0To10"
           | }
         """.stripMargin).get
-      validatorWithRangeFormat.validate(schema, JsNumber(10)).isSuccess must beTrue
-      validatorWithRangeFormat.validate(schema, JsNumber(-1)).isError must beTrue
+
+      val integerSchema = JsonSource.schemaFromString(
+        """
+          |{
+          |  "type": "integer",
+          |  "format": "range0To10"
+          | }
+        """.stripMargin).get
+
+      validatorWithRangeFormat.validate(integerSchema, JsNumber(10)).isSuccess must beTrue
+      validatorWithRangeFormat.validate(integerSchema, JsNumber(-1)).isError must beTrue
+
+      validatorWithRangeFormat.validate(numberSchema, JsNumber(10)).isSuccess must beTrue
+      validatorWithRangeFormat.validate(numberSchema, JsNumber(-1)).isError must beTrue
     }
   }
 }


### PR DESCRIPTION
`integer` type now also supports `format` keyword.