### PR TITLE
Fix for issue #103: schema passed as URL argument is not cached

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/SchemaValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/SchemaValidator.scala
@@ -22,8 +22,70 @@ trait HasLang {
   implicit val lang: Lang
 }
 
-trait CanValidate {
-  self: Customizations with HasLang =>
+/**
+  * The schema validator.
+  *
+  * @param refResolver the reference resolver
+  */
+case class SchemaValidator(refResolver: SchemaRefResolver = new SchemaRefResolver,
+                           formats: Map[String, SchemaFormat] = DefaultFormats.formats)
+                          (implicit val lang: Lang = Lang.Default)
+  extends Customizations with HasLang {
+
+  /**
+    * Add a URLStreamHandler that is capable of handling absolute with a specific scheme.
+    *
+    * @param handler the UrlHandler to be added
+    * @return a new validator instance
+    */
+  def addUrlHandler(handler: URLStreamHandler, scheme: String): SchemaValidator =
+    copy(refResolver =
+      refResolver.copy(resolverFactory =
+        refResolver.resolverFactory.addUrlHandler(scheme, handler)))
+
+  /**
+    * Add a relative URLStreamHandler that is capable of resolving relative references.
+    * Optionally takes a protocol that determines for which schemes the
+    * handler should be triggered.
+    *
+    * @param handler the relative handler to be added
+    * @return the validator instance with the handler being added
+    */
+  def addRelativeUrlHandler(handler: URLStreamHandler, scheme: String = UrlHandler.ProtocolLessScheme): SchemaValidator =
+    copy(refResolver =
+      refResolver.copy(resolverFactory =
+        refResolver.resolverFactory.addRelativeUrlHandler(scheme, handler)))
+
+
+  /**
+    * Add a custom format
+    *
+    * @param format the custom format
+    * @return a new validator instance containing the custom format
+    */
+  def addFormat(format: SchemaFormat): SchemaValidator =
+    copy(formats = formats + (format.name -> format))
+
+  /**
+    * Add a schema.
+    *
+    * @param id the id of the schema
+    * @param schema the schema
+    */
+  def addSchema(id: String, schema: SchemaType): SchemaValidator = {
+    copy(refResolver =
+      refResolver.copy(cache =
+        refResolver.cache.add(Ref(id))(schema))
+    )
+  }
+
+  private def buildContext(schema: SchemaType, schemaUrl: URL): SchemaResolutionContext = {
+    val id = schema.constraints.any.id.map(Ref)
+    SchemaResolutionContext(refResolver,
+      new SchemaResolutionScope(schema, id.orElse(Some(Ref(schemaUrl.toString)))),
+      formats = formats
+    )
+  }
 
   /**
     * Validate the given JsValue against the schema located at the given URL.
@@ -33,18 +95,21 @@ trait CanValidate {
     * @return a JsResult holding the validation result
     */
   def validate(schemaUrl: URL, input: => JsValue): JsResult[JsValue] = {
-    def buildContext(schema: SchemaType): SchemaResolutionContext = {
-      val id = schema.constraints.any.id.map(Ref)
-      SchemaResolutionContext(refResolver,
-        new SchemaResolutionScope(schema, id.orElse(Some(Ref(schemaUrl.toString)))),
-        formats = formats
-      )
+    val ref = Ref(schemaUrl.toString)
+    refResolver.cache.get(ref) match {
+      case None =>
+        for {
+          schema <- JsonSource.schemaFromUrl(schemaUrl)
+          context = buildContext(schema, schemaUrl)
+          result <- schema.validate(input, context).toJsResult
+        } yield {
+          refResolver.cache = refResolver.cache.add(ref)(schema)
+          result
+        }
+      case Some(schema) =>
+        val context = buildContext(schema, schemaUrl)
+        schema.validate(input, context).toJsResult
     }
-
-    for {
-      schema <- JsonSource.schemaFromUrl(schemaUrl)
-      result <- schema.validate(input, buildContext(schema)).toJsResult
-    } yield result
   }
 
   /**
@@ -111,10 +176,8 @@ trait CanValidate {
       new SchemaResolutionScope(schema, id),
       formats = formats
     )
-    schema.validate(
-      input,
-      context
-    ).toJsResult
+
+    schema.validate(input, context).toJsResult
   }
 
   /**
@@ -197,63 +260,5 @@ trait CanValidate {
           }
         )
     }
-  }
-}
-
-/**
-  * The schema validator.
-  *
-  * @param refResolver the reference resolver
-  */
-case class SchemaValidator(refResolver: SchemaRefResolver = new SchemaRefResolver,
-                           formats: Map[String, SchemaFormat] = DefaultFormats.formats)
-                          (implicit val lang: Lang = Lang.Default)
-  extends CanValidate with Customizations with HasLang {
-
-  /**
-    * Add a URLStreamHandler that is capable of handling absolute with a specific scheme.
-    *
-    * @param handler the UrlHandler to be added
-    * @return a new validator instance
-    */
-  def addUrlHandler(handler: URLStreamHandler, scheme: String): SchemaValidator =
-    copy(refResolver =
-      refResolver.copy(resolverFactory =
-        refResolver.resolverFactory.addUrlHandler(scheme, handler)))
-
-  /**
-    * Add a relative URLStreamHandler that is capable of resolving relative references.
-    * Optionally takes a protocol that determines for which schemes the
-    * handler should be triggered.
-    *
-    * @param handler the relative handler to be added
-    * @return the validator instance with the handler being added
-    */
-  def addRelativeUrlHandler(handler: URLStreamHandler, scheme: String = UrlHandler.ProtocolLessScheme): SchemaValidator =
-    copy(refResolver =
-      refResolver.copy(resolverFactory =
-        refResolver.resolverFactory.addRelativeUrlHandler(scheme, handler)))
-
-
-  /**
-    * Add a custom format
-    *
-    * @param format the custom format
-    * @return a new validator instance containing the custom format
-    */
-  def addFormat(format: SchemaFormat): SchemaValidator =
-    copy(formats = formats + (format.name -> format))
-
-  /**
-    * Add a schema.
-    *
-    * @param id the id of the schema
-    * @param schema the schema
-    */
-  def addSchema(id: String, schema: SchemaType): SchemaValidator = {
-    copy(refResolver =
-      refResolver.copy(cache =
-        refResolver.cache.add(Ref(id))(schema))
-    )
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/SimplePerformanceSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/SimplePerformanceSpec.scala
@@ -1,0 +1,30 @@
+package com.eclipsesource.schema
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.Json
+
+class SimplePerformanceSpec extends Specification {
+
+  def timed(name: String)(body: => Unit) {
+    val start = System.currentTimeMillis()
+    body
+    println(name + ": " + (System.currentTimeMillis() - start) + " ms")
+  }
+
+  val validator = SchemaValidator()
+  val schemaUrl = getClass.getResource("/issue-99-1.json")
+  val schema = JsonSource.schemaFromUrl(schemaUrl).get
+
+  val instance = Json.parse(
+    """{
+      |"mything": "the thing"
+      |}""".stripMargin)
+
+  timed("preloaded") {
+    for (_ <- 1 to 1000) validator.validate(schema, instance)
+  }
+  timed("url based") {
+    for (_ <- 1 to 1000) validator.validate(schemaUrl, instance)
+  }
+
+}


### PR DESCRIPTION
Inline `CanValidate` trait into validator and update cache when `validate` has been called