### PR TITLE
Minor change to validation pattern for email format

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/internal/validators/DefaultFormats.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/DefaultFormats.scala
@@ -94,9 +94,8 @@ object DefaultFormats {
   }
 
   object EmailFormat extends SchemaFormat {
-
-    // http://stackoverflow.com/questions/201323/using-a-regular-expression-to-validate-an-email-address
-    private val CompiledEmailPattern = Pattern.compile("^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\\.[a-zA-Z0-9-.]+$")
+    val Email = "^([a-zA-Z0-9.!#$%&’'*+/=?^_`{|}~-]+)@([a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*)$"
+    private val CompiledEmailPattern = Pattern.compile(Email)
 
     override def name: String = "email"
     override def validate(json: JsValue): Boolean = json match {

--- a/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/FormatSpec.scala
@@ -17,6 +17,19 @@ class FormatSpec extends Specification with JsonSpec {
       result.isSuccess must beTrue
     }
 
+    "validate emails" in {
+      val schema = JsonSource.schemaFromString(
+        """
+          |{
+          |  "type": "string",
+          |  "format": "email"
+          |}
+        """.stripMargin).get
+      val validator = SchemaValidator()
+      validator.validate(schema, JsString("a%d33@example.co.uk")).isSuccess must beTrue
+      validator.validate(schema, JsString(".@.....")).isError must beTrue
+    }
+
     "validate UUIDs" in {
       val schema = JsonSource.schemaFromString(
         """


### PR DESCRIPTION
This is a terrific library. Thank you for sharing your work.

This is a minor change to email validation to bring it in line with RFC 5322, section 3.4.1 ([link](https://tools.ietf.org/html/rfc5322#section-3.4.1)) as mentioned in the JSON schema validation spec ([link](http://json-schema.org/latest/json-schema-validation.html#rfc.section.7.3.2)).

Pattern comes from hmrc/emailaddress ([link](https://github.com/hmrc/emailaddress/blob/master/src/main/scala/uk/gov/hmrc/emailaddress/EmailAddress.scala)).