### PR TITLE
Streamline validate signatures, remove essentialErrorInfo

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/internal/refs/Ref.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/Ref.scala
@@ -138,4 +138,3 @@ object Ref {
 case class LocalRef(value: String) extends Ref
 case class RelativeRef(value: String) extends Ref
 case class AbsoluteRef(value: String) extends Ref
-

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
@@ -23,8 +23,8 @@ case class ResolvedResult(resolved: SchemaType, scope: SchemaResolutionScope)
 case class SchemaRefResolver
 (
   version: SchemaVersion,
-  resolverFactory: UrlStreamResolverFactory = UrlStreamResolverFactory(),
-  private[schema] val cache: DocumentCache = DocumentCache()
+  cache: DocumentCache = DocumentCache(),
+  resolverFactory: UrlStreamResolverFactory = UrlStreamResolverFactory()
 ) {
 
   import version._
@@ -74,12 +74,6 @@ case class SchemaRefResolver
 
         case r if cache.contains(r) =>
           ResolvedResult(cache(r), scope).right[JsonValidationError]
-
-          // check if ref is contained in a subschema
-          // can also apply to relative URLs if not resolution scope is available
-        case r if scope.subSchemas.keySet.contains(r.value) =>
-          cache.mapping ++= scope.subSchemas
-          ResolvedResult(scope.subSchemas(r.value), scope).right[JsonValidationError]
 
         // check if any prefix of ref matches current element
         case a@AbsoluteRef(absoluteRef)  =>

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaResolutionScope.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaResolutionScope.scala
@@ -1,7 +1,8 @@
 package com.eclipsesource.schema.internal.refs
 
-import com.eclipsesource.schema.{SchemaArray, SchemaObject, SchemaRoot, SchemaTuple, SchemaType}
+import com.eclipsesource.schema.SchemaType
 import play.api.libs.json.JsPath
+import com.eclipsesource.schema.internal._
 
 case class SchemaResolutionScope(documentRoot: SchemaType,
                                  id: Option[Ref] = None, // current resolution scope
@@ -10,46 +11,18 @@ case class SchemaResolutionScope(documentRoot: SchemaType,
                                  depth: Int = 0,
                                  referrer: Option[JsPath] = None
                                 ) {
-
-  lazy val subSchemas: Map[String, SchemaType] =
-    collectSchemas(documentRoot.asInstanceOf[SchemaType], id, Map())
-
-  /**
-    * Traverse the given schema and returns a Map of Refs representing the resolution scope of the mapped
-    * schema elements.
-    * @param schema the schema element to be traversed
-    * @param resolutionScope the current resolution scope
-    * @param knownSchemas Map containing all found scopes so far
-    * @return Map containing all found scopes
-    */
-  private def collectSchemas(schema: SchemaType, resolutionScope: Option[Ref], knownSchemas: Map[String, SchemaType]): Map[String, SchemaType] = {
-
-    val currentScope = schema.constraints.id.map(i => Refs.mergeRefs(Ref(i), resolutionScope))
-    val updatedMap = currentScope.fold(knownSchemas)(id => knownSchemas + (id.value -> schema))
-    val m = schema match {
-      case SchemaObject(props, _, _) => props.foldLeft(updatedMap) {
-        (schemas, prop) => {
-          collectSchemas(prop.schemaType, currentScope orElse resolutionScope, schemas)
-        }
-      }
-      case SchemaArray(item, _, _) => collectSchemas(item, currentScope, updatedMap)
-      case SchemaTuple(items, _, _) => items.foldLeft(updatedMap) {
-        (schemas, item) =>  collectSchemas(item, currentScope, schemas)
-      }
-      case SchemaRoot(_ ,s) => collectSchemas(s, resolutionScope, updatedMap)
-      case _ => updatedMap
-    }
-
-    schema.constraints.subSchemas.foldLeft(m) {
-      (schemas, s) => collectSchemas(s, currentScope orElse resolutionScope, schemas)
-    }
-  }
+  lazy val subSchemas: Map[String, SchemaType] = collectSchemas(documentRoot, id, Map())
 }
 
 case class DocumentCache(mapping: collection.concurrent.Map[String, SchemaType] = collection.concurrent.TrieMap.empty[String, SchemaType]) {
 
   def add(id: Ref)(schemaType: SchemaType): DocumentCache = {
     mapping += (id.value -> schemaType)
+    this
+  }
+
+  def addAll(schemas: Map[String, SchemaType]): DocumentCache = {
+    mapping ++= schemas
     this
   }
 

--- a/src/test/scala/com/eclipsesource/schema/ExamplesSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/ExamplesSpec.scala
@@ -12,7 +12,7 @@ class ExamplesSpec extends Specification {
     val schemaUrl = getClass.getResource(url)
     val instanceUrl = getClass.getResource(url)
     val instance = JsonSource.fromUrl(instanceUrl)
-    val result   = validator.validate(schemaUrl, instance.get)
+    val result   = validator.validate(schemaUrl)(instance.get)
     result.isSuccess must beTrue
     result.get must beEqualTo(instance.get)
   }

--- a/src/test/scala/com/eclipsesource/schema/Issue99Spec.scala
+++ b/src/test/scala/com/eclipsesource/schema/Issue99Spec.scala
@@ -1,6 +1,6 @@
 package com.eclipsesource.schema
 
-import com.eclipsesource.schema.drafts.{Version4, Version7}
+import com.eclipsesource.schema.drafts.Version4
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 
@@ -35,7 +35,7 @@ class Issue99Spec extends Specification { self =>
     "validate issue 99-1 test case via URL" in {
       val schemaUrl = self.getClass.getResource("/issue-99-1.json")
       val validator = SchemaValidator(Some(Version4))
-      val result = validator.validate(schemaUrl, Json.obj(
+      val result = validator.validate(schemaUrl)(Json.obj(
         "mything" -> "test"
       ))
       result.isSuccess must beTrue
@@ -45,7 +45,7 @@ class Issue99Spec extends Specification { self =>
       val schemaUrl = self.getClass.getResource("/issue-99-5.json")
       val validator = SchemaValidator(Some(Version4))
       // must terminate
-      validator.validate(schemaUrl, Json.obj(
+      validator.validate(schemaUrl)(Json.obj(
         "mything" -> "test"
       )).isError must beTrue
     }

--- a/src/test/scala/com/eclipsesource/schema/SchemaValidatorSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/SchemaValidatorSpec.scala
@@ -106,7 +106,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     }
 
     "be validated via file based resource URL" in {
-      SchemaValidator(Some(Version4)).validate(resourceUrl, instance).isSuccess must beTrue
+      SchemaValidator(Some(Version4)).validate(resourceUrl)(instance).isSuccess must beTrue
     }
 
     "validate via file based URL and Reads" in {
@@ -121,6 +121,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     "validate via file based URL and Writes" in {
       val talk = Talk(Location("Munich"))
       val result = SchemaValidator(Some(Version4)).validate(resourceUrl, talk, talkWrites)
+      println(result)
       result.isSuccess must beTrue
     }
 
@@ -157,7 +158,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
   "Remote ref" should {
     "validate" in new WithServer(app = createApp, port = 1234) {
       val resourceUrl: URL = new URL("http://localhost:1234/talk.json")
-      SchemaValidator(Some(Version4)).validate(resourceUrl, instance).isSuccess must beTrue
+      SchemaValidator(Some(Version4)).validate(resourceUrl)(instance).isSuccess must beTrue
     }
   }
 

--- a/src/test/scala/com/eclipsesource/schema/SchemaValidatorSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/SchemaValidatorSpec.scala
@@ -121,7 +121,6 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     "validate via file based URL and Writes" in {
       val talk = Talk(Location("Munich"))
       val result = SchemaValidator(Some(Version4)).validate(resourceUrl, talk, talkWrites)
-      println(result)
       result.isSuccess must beTrue
     }
 
@@ -183,9 +182,10 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     val result: JsResult[Foo] = SchemaValidator(Some(Version4))
       .addSchema("http://localhost:1234/location.json", locationSchema)
       .validate(schema, fooInstance, lr)
-    result.asEither must beLeft.like { case error =>
-      (error.toJson(0) \ "instancePath") must beEqualTo(JsDefined(JsString("/loc")))
+    result.asEither must beLeft.which {
+      _.head._2.head.message must beEqualTo("error.path.missing")
     }
+    result.isError must beTrue
   }
 
   "should fail with message in case a ref can not be resolved" in {

--- a/src/test/scala/com/eclipsesource/schema/SimplePerformanceSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/SimplePerformanceSpec.scala
@@ -1,8 +1,10 @@
 package com.eclipsesource.schema
 
+import java.net.URL
+
 import com.eclipsesource.schema.drafts.Version4
 import org.specs2.mutable.Specification
-import play.api.libs.json.Json
+import play.api.libs.json.{JsValue, Json}
 
 class SimplePerformanceSpec extends Specification {
 
@@ -15,19 +17,16 @@ class SimplePerformanceSpec extends Specification {
   }
 
   val validator = SchemaValidator(Some(Version4))
-  val schemaUrl = getClass.getResource("/issue-99-1.json")
-  val schema = JsonSource.schemaFromUrl(schemaUrl).get
+  val schemaUrl: URL = getClass.getResource("/issue-99-1.json")
+  val schema: SchemaType = JsonSource.schemaFromUrl(schemaUrl).get
 
-  val instance = Json.parse(
-    """{
-      |"mything": "the thing"
-      |}""".stripMargin)
+  val instance: JsValue = Json.parse("""{ "mything": "the thing" }""".stripMargin)
 
   timed("preloaded") {
     for (_ <- 1 to 1000) validator.validate(schema, instance)
   }
   timed("url based") {
-    for (_ <- 1 to 1000) validator.validate(schemaUrl, instance)
+    for (_ <- 1 to 1000) validator.validate(schemaUrl)(instance)
   }
 
 }

--- a/src/test/scala/com/eclipsesource/schema/UrlHandlerSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/UrlHandlerSpec.scala
@@ -37,7 +37,7 @@ class UrlHandlerSpec extends Specification {
     "should resolve protocol-ful relative references on the classpath with ClasspathUrlProtocolHandler (invalid instance)" in {
       val validator = SchemaValidator(Some(Version4))
       val url = clazz.getResource("/schemas/my-schema-with-protocol-ful-relative-path.schema")
-      validator.validate(url, Json.obj("foo" -> Json.obj("bar" -> "Munich")))
+      validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> "Munich")))
          .isError must beTrue
     }
 
@@ -45,14 +45,14 @@ class UrlHandlerSpec extends Specification {
     "should resolve protocol-less relative references on the classpath via default behaviour (valid instance)" in {
       val validator = SchemaValidator(Some(Version4))
       val url = clazz.getResource("/schemas/my-schema-with-protocol-less-relative-path.schema")
-      validator.validate(url, Json.obj("foo" -> Json.obj("bar" -> "Munich")))
+      validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> "Munich")))
         .isSuccess must beTrue
     }
 
     "should resolve protocol-less relative references on the classpath with via default behaviour (invalid instance)" in {
       val validator = SchemaValidator(Some(Version4))
       val url = clazz.getResource("/schemas/my-schema-with-protocol-less-relative-path.schema")
-      validator.validate(url, Json.obj("foo" -> Json.obj("bar" -> 3)))
+      validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> 3)))
         .isError must beTrue
     }
 
@@ -67,21 +67,21 @@ class UrlHandlerSpec extends Specification {
     "should resolve protocol-less relative references on the classpath with custom relative URL handler (valid instance)" in {
       val validator = SchemaValidator(Some(Version4)).addRelativeUrlHandler(new MyUrlHandler)
       val url = clazz.getResource("/issue-65/schemas/my-schema-with-protocol-less-relative-path.schema")
-      val result = validator.validate(url, Json.obj("foo" -> Json.obj("bar" -> "Munich")))
+      val result = validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> "Munich")))
       result.isSuccess must beTrue
     }
 
     "should resolve protocol-less relative references on the classpath with custom relative URL handler (invalid instance)" in {
       val validator = SchemaValidator(Some(Version4)).addRelativeUrlHandler(new MyUrlHandler)
       val url = clazz.getResource("/issue-65/schemas/my-schema-with-protocol-less-relative-path.schema")
-      val invalidResult = validator.validate(url, Json.obj("quux" -> Json.obj("bar" -> 3)))
+      val invalidResult = validator.validate(url)(Json.obj("quux" -> Json.obj("bar" -> 3)))
       invalidResult.isError must beTrue
     }
 
     "should fail resolving protocol-less relative references on the classpath if no relative URL handler registered" in {
       val validator = SchemaValidator(Some(Version4))
       val url = clazz.getResource("/issue-65/schemas/my-schema-with-protocol-less-relative-path.schema")
-      validator.validate(url, Json.obj("quux" -> "Munich"))
+      validator.validate(url)(Json.obj("quux" -> "Munich"))
         .isError must beTrue
     }
   }

--- a/src/test/scala/com/eclipsesource/schema/internal/refs/DraftExamplesSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/refs/DraftExamplesSpec.scala
@@ -1,6 +1,7 @@
 package com.eclipsesource.schema.internal.refs
 
 import com.eclipsesource.schema.drafts.Version4
+import com.eclipsesource.schema.internal._
 import com.eclipsesource.schema.{JsonSource, SchemaInteger}
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsString, JsValue, Json}
@@ -131,7 +132,10 @@ class DraftExamplesSpec extends Specification {
         |}""".
         stripMargin
     ).get
-    val resolver = SchemaRefResolver(Version4)
+    val resolver = SchemaRefResolver(
+      Version4,
+      DocumentCache().addAll(collectSchemas(mySiteSchema, Some(Ref("http://my.site/myschema#"))))
+    )
     val scope = SchemaResolutionScope(mySiteSchema)
 
     "resolve schema1 via plain name fragment" in {


### PR DESCRIPTION
- Move `collectSchemas` and call it prior to actual validation
- Streamline `validate` signatures
- Remove `essentialErrorInfo` as it adds little to no value