### PR TITLE
Remove dependencies to externals

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ cache:
     - $HOME/.sbt/boot/
 
 script:
-  - sbt -sbt-version 0.13.9 -scala-version $TRAVIS_SCALA_VERSION clean coverage test
+  - sbt -sbt-version 0.13.11 -scala-version $TRAVIS_SCALA_VERSION clean coverage test
 
 after_success:
   - sbt coverageReport coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 language: scala
 
 scala:
-  - "2.12.1"
+  - "2.12.6"
 
 jdk:
   - oraclejdk8

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -49,8 +49,8 @@ object Build extends Build {
 
   val commonSettings = Seq(
       organization := "com.eclipsesource",
-      scalaVersion := "2.12.2",
-      crossScalaVersions := Seq("2.11.11", "2.12.2"),
+      scalaVersion := "2.12.6",
+      crossScalaVersions := Seq("2.11.11", "2.12.6"),
       licenses := Seq("Apache-2.0" -> url("http://www.apache.org/licenses/LICENSE-2.0")),
       Keys.fork in Test := false,
       Keys.parallelExecution in Test := false

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -7,8 +7,8 @@ resolvers += Classpaths.sbtPluginReleases
 
 addSbtPlugin("me.lessis" % "bintray-sbt" % "0.3.0")
 
-addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.0")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.5.1")
 
-addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.1.0")
+addSbtPlugin("org.scoverage" % "sbt-coveralls" % "1.2.5")
 
 addSbtPlugin("com.github.gseitz" % "sbt-release" % "1.0.3")

--- a/src/main/resources/json-schema-draft-04.json
+++ b/src/main/resources/json-schema-draft-04.json
@@ -1,0 +1,149 @@
+{
+    "id": "http://json-schema.org/draft-04/schema#",
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "description": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "positiveInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "positiveIntegerDefault0": {
+            "allOf": [ { "$ref": "#/definitions/positiveInteger" }, { "default": 0 } ]
+        },
+        "simpleTypes": {
+            "enum": [ "array", "boolean", "integer", "null", "number", "object", "string" ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "minItems": 1,
+            "uniqueItems": true
+        }
+    },
+    "type": "object",
+    "properties": {
+        "id": {
+            "type": "string"
+        },
+        "$schema": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": {},
+        "multipleOf": {
+            "type": "number",
+            "minimum": 0,
+            "exclusiveMinimum": true
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "boolean",
+            "default": false
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxLength": { "$ref": "#/definitions/positiveInteger" },
+        "minLength": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": {}
+        },
+        "maxItems": { "$ref": "#/definitions/positiveInteger" },
+        "minItems": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "maxProperties": { "$ref": "#/definitions/positiveInteger" },
+        "minProperties": { "$ref": "#/definitions/positiveIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": {
+            "anyOf": [
+                { "type": "boolean" },
+                { "$ref": "#" }
+            ],
+            "default": {}
+        },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "enum": {
+            "type": "array",
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "dependencies": {
+        "exclusiveMaximum": [ "maximum" ],
+        "exclusiveMinimum": [ "minimum" ]
+    },
+    "default": {}
+}

--- a/src/main/resources/json-schema-draft-07.json
+++ b/src/main/resources/json-schema-draft-07.json
@@ -1,0 +1,168 @@
+{
+    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$id": "http://json-schema.org/draft-07/schema#",
+    "title": "Core schema meta-schema",
+    "definitions": {
+        "schemaArray": {
+            "type": "array",
+            "minItems": 1,
+            "items": { "$ref": "#" }
+        },
+        "nonNegativeInteger": {
+            "type": "integer",
+            "minimum": 0
+        },
+        "nonNegativeIntegerDefault0": {
+            "allOf": [
+                { "$ref": "#/definitions/nonNegativeInteger" },
+                { "default": 0 }
+            ]
+        },
+        "simpleTypes": {
+            "enum": [
+                "array",
+                "boolean",
+                "integer",
+                "null",
+                "number",
+                "object",
+                "string"
+            ]
+        },
+        "stringArray": {
+            "type": "array",
+            "items": { "type": "string" },
+            "uniqueItems": true,
+            "default": []
+        }
+    },
+    "type": ["object", "boolean"],
+    "properties": {
+        "$id": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$schema": {
+            "type": "string",
+            "format": "uri"
+        },
+        "$ref": {
+            "type": "string",
+            "format": "uri-reference"
+        },
+        "$comment": {
+            "type": "string"
+        },
+        "title": {
+            "type": "string"
+        },
+        "description": {
+            "type": "string"
+        },
+        "default": true,
+        "readOnly": {
+            "type": "boolean",
+            "default": false
+        },
+        "examples": {
+            "type": "array",
+            "items": true
+        },
+        "multipleOf": {
+            "type": "number",
+            "exclusiveMinimum": 0
+        },
+        "maximum": {
+            "type": "number"
+        },
+        "exclusiveMaximum": {
+            "type": "number"
+        },
+        "minimum": {
+            "type": "number"
+        },
+        "exclusiveMinimum": {
+            "type": "number"
+        },
+        "maxLength": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minLength": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "pattern": {
+            "type": "string",
+            "format": "regex"
+        },
+        "additionalItems": { "$ref": "#" },
+        "items": {
+            "anyOf": [
+                { "$ref": "#" },
+                { "$ref": "#/definitions/schemaArray" }
+            ],
+            "default": true
+        },
+        "maxItems": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minItems": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "uniqueItems": {
+            "type": "boolean",
+            "default": false
+        },
+        "contains": { "$ref": "#" },
+        "maxProperties": { "$ref": "#/definitions/nonNegativeInteger" },
+        "minProperties": { "$ref": "#/definitions/nonNegativeIntegerDefault0" },
+        "required": { "$ref": "#/definitions/stringArray" },
+        "additionalProperties": { "$ref": "#" },
+        "definitions": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "properties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "default": {}
+        },
+        "patternProperties": {
+            "type": "object",
+            "additionalProperties": { "$ref": "#" },
+            "propertyNames": { "format": "regex" },
+            "default": {}
+        },
+        "dependencies": {
+            "type": "object",
+            "additionalProperties": {
+                "anyOf": [
+                    { "$ref": "#" },
+                    { "$ref": "#/definitions/stringArray" }
+                ]
+            }
+        },
+        "propertyNames": { "$ref": "#" },
+        "const": true,
+        "enum": {
+            "type": "array",
+            "items": true,
+            "minItems": 1,
+            "uniqueItems": true
+        },
+        "type": {
+            "anyOf": [
+                { "$ref": "#/definitions/simpleTypes" },
+                {
+                    "type": "array",
+                    "items": { "$ref": "#/definitions/simpleTypes" },
+                    "minItems": 1,
+                    "uniqueItems": true
+                }
+            ]
+        },
+        "format": { "type": "string" },
+        "contentMediaType": { "type": "string" },
+        "contentEncoding": { "type": "string" },
+        "if": {"$ref": "#"},
+        "then": {"$ref": "#"},
+        "else": {"$ref": "#"},
+        "allOf": { "$ref": "#/definitions/schemaArray" },
+        "anyOf": { "$ref": "#/definitions/schemaArray" },
+        "oneOf": { "$ref": "#/definitions/schemaArray" },
+        "not": { "$ref": "#" }
+    },
+    "default": true
+}

--- a/src/main/scala/com/eclipsesource/schema/SchemaAST.scala
+++ b/src/main/scala/com/eclipsesource/schema/SchemaAST.scala
@@ -31,7 +31,7 @@ case class SchemaRoot($schema: Option[SchemaVersion], schema: SchemaType) extend
 }
 
 final case class CompoundSchemaType(alternatives: Seq[SchemaType]) extends SchemaType {
-  override def toString: String = alternatives.map(_.toString).mkString(" ")
+  override def toString: String = s"[${alternatives.map(_.toString).mkString(", ")}]"
   override def constraints: Constraint = NoConstraints()
 }
 

--- a/src/main/scala/com/eclipsesource/schema/drafts/Version4.scala
+++ b/src/main/scala/com/eclipsesource/schema/drafts/Version4.scala
@@ -2,13 +2,16 @@ package com.eclipsesource.schema.drafts
 
 import com.eclipsesource.schema.internal.draft4.{SchemaReads4, SchemaWrites4}
 import com.eclipsesource.schema.internal.validators.DefaultFormats
-import com.eclipsesource.schema.{SchemaConfigOptions, SchemaFormat, SchemaVersion}
+import com.eclipsesource.schema.{JsonSource, SchemaConfigOptions, SchemaFormat, SchemaType, SchemaVersion}
 
 trait Version4 extends SchemaVersion with SchemaReads4 with SchemaWrites4
 
-object Version4 extends SchemaVersion with SchemaReads4 with SchemaWrites4 {
+object Version4 extends Version4 { self =>
   val SchemaUrl = "http://json-schema.org/draft-04/schema#"
   val schemaLocation: String = SchemaUrl
+  lazy val Schema: SchemaType =
+    JsonSource.schemaFromUrl(self.getClass.getResource("/json-schema-draft-04.json"))
+      .getOrElse(throw new RuntimeException("Could not read schema file json-schema-draft-04.json."))
   val options: SchemaConfigOptions = new SchemaConfigOptions {
     override def supportsExternalReferences: Boolean = true
     override def formats: Map[String, SchemaFormat] = DefaultFormats.formats

--- a/src/main/scala/com/eclipsesource/schema/drafts/Version7.scala
+++ b/src/main/scala/com/eclipsesource/schema/drafts/Version7.scala
@@ -2,13 +2,16 @@ package com.eclipsesource.schema.drafts
 
 import com.eclipsesource.schema.internal.draft7.{SchemaReads7, SchemaWrites7}
 import com.eclipsesource.schema.internal.validators.DefaultFormats
-import com.eclipsesource.schema.{SchemaConfigOptions, SchemaFormat, SchemaVersion}
+import com.eclipsesource.schema.{JsonSource, SchemaConfigOptions, SchemaFormat, SchemaType, SchemaVersion}
 
 trait Version7 extends SchemaVersion with SchemaReads7 with SchemaWrites7
 
-object Version7 extends Version7 {
+object Version7 extends Version7 { self =>
   val SchemaUrl = "http://json-schema.org/draft-07/schema#"
   val schemaLocation: String = SchemaUrl
+  lazy val Schema: SchemaType =
+    JsonSource.schemaFromUrl(self.getClass.getResource("/json-schema-draft-07.json"))
+      .getOrElse(throw new RuntimeException("Could not read schema file json-schema-draft-07.json."))
   val options: SchemaConfigOptions = new SchemaConfigOptions {
     override def supportsExternalReferences: Boolean = false
     override def formats: Map[String, SchemaFormat] = DefaultFormats.formats

--- a/src/main/scala/com/eclipsesource/schema/internal/Results.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/Results.scala
@@ -35,21 +35,12 @@ object Results {
                       instance: JsValue,
                       additionalInfo: JsObject = Json.obj()): VA[JsValue] = {
 
-    def dropSlashIfAny(path: String) = if (path.startsWith("/#")) path.substring(1) else path
-
     Failure(Seq(context.instancePath ->
-      Seq(JsonValidationError(msg,
-        Json.obj(
-          "keyword" -> keyword,
-          "schemaPath" -> dropSlashIfAny(context.schemaPath.toString()),
-          "instancePath" -> context.instancePath.toString(),
-          "value" -> instance,
-          "errors" ->  additionalInfo
-        ) ++ context.scope.id.fold(Json.obj())(id =>
-          Json.obj("resolutionScope" -> id.value)
-        ) ++ context.scope.referrer.fold(Json.obj())(referrer =>
-          Json.obj("referrer" -> dropSlashIfAny(referrer.toString()))
-        )
+      Seq(JsonValidationError(
+        msg,
+        SchemaUtil.createErrorObject(keyword, context.schemaPath, context.instancePath, instance, additionalInfo)
+          ++ context.scope.id.fold(Json.obj())(id => Json.obj("resolutionScope" -> id.value))
+          ++ context.scope.referrer.fold(Json.obj())(referrer => Json.obj("referrer" -> SchemaUtil.dropSlashIfAny(referrer.toString())))
       ))
     ))
   }

--- a/src/main/scala/com/eclipsesource/schema/internal/package.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/package.scala
@@ -49,24 +49,17 @@ package object internal {
 
   def failure(keyword: String,
               msg: String,
-              schemaPath: JsPath,
+              schemaPath: Option[JsPath],
               instancePath: JsPath,
               instance: JsValue,
               additionalInfo: JsObject = Json.obj()
              ): Validated[JsonValidationError, JsValue] = {
 
-    def dropSlashIfAny(path: String) = if (path.startsWith("/#")) path.substring(1) else path
-
     Failure(
       Seq(
-        JsonValidationError(msg,
-          Json.obj(
-            "keyword" -> keyword,
-            "schemaPath" -> dropSlashIfAny(schemaPath.toString()),
-            "instancePath" -> instancePath.toString(),
-            "value" -> instance,
-            "errors" ->  additionalInfo
-          )
+        JsonValidationError(
+          msg,
+          SchemaUtil.createErrorObject(keyword, schemaPath, instancePath, instance, additionalInfo)
         )
       )
     )

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/Ref.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/Ref.scala
@@ -31,7 +31,6 @@ object Refs {
         ).getOrElse(l)
 
       case r@RelativeRef(relativeRef) =>
-
         if (relativeRef.startsWith("#")) {
           // ref is plain name fragment
           currentScope.map(url =>

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaResolutionScope.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaResolutionScope.scala
@@ -6,12 +6,15 @@ import com.eclipsesource.schema.internal._
 
 case class SchemaResolutionScope(documentRoot: SchemaType,
                                  id: Option[Ref] = None, // current resolution scope
-                                 schemaPath: JsPath = JsPath \ "#",
+                                 schemaJsPath: Option[JsPath] = None,
                                  instancePath: JsPath = JsPath,
                                  depth: Int = 0,
                                  referrer: Option[JsPath] = None
                                 ) {
-  lazy val subSchemas: Map[String, SchemaType] = collectSchemas(documentRoot, id, Map())
+
+
+  def schemaPath: Option[String] = schemaJsPath.map(jsPath => SchemaUtil.dropSlashIfAny(jsPath.toString()))
+
 }
 
 case class DocumentCache(mapping: collection.concurrent.Map[String, SchemaType] = collection.concurrent.TrieMap.empty[String, SchemaType]) {

--- a/src/main/scala/com/eclipsesource/schema/internal/url/UrlStreamResolverFactory.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/url/UrlStreamResolverFactory.scala
@@ -15,7 +15,4 @@ case class UrlStreamResolverFactory(
   def addUrlHandler(protocolEntry: (String, URLStreamHandler)): UrlStreamResolverFactory =
     copy(protocolUrlHandlers = protocolUrlHandlers + protocolEntry)
 
-  def addRelativeUrlHandler(handler: (String, URLStreamHandler)): UrlStreamResolverFactory =
-    copy(relativeUrlHandlers = relativeUrlHandlers + (handler._1 -> handler._2))
-
 }

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayConstraintValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayConstraintValidators.scala
@@ -21,7 +21,7 @@ object ArrayConstraintValidators {
                 .getOrElse(SchemaUtil.failure(
                   "contains",
                   Messages("err.contains"),
-                  context.schemaPath \ "contains",
+                  context.schemaPath.map(_ \ "contains"),
                   context.instancePath,
                   json
                 ))

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ObjectValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ObjectValidators.scala
@@ -24,7 +24,7 @@ object ObjectValidators {
               JsString(field._1),
               context.updateScope(
                 _.copy(
-                  schemaPath = context.schemaPath \ "propertyNames",
+                  schemaJsPath = context.schemaPath.map(_ \ "propertyNames"),
                   instancePath = context.instancePath \ field._1
                 )
               )
@@ -61,7 +61,7 @@ object ObjectValidators {
                 value,
                 context.updateScope(
                   _.copy(
-                    schemaPath = context.schemaPath \ "properties" \ attr.name,
+                    schemaJsPath = context.schemaPath.map(_ \ "properties" \ attr.name),
                     instancePath = context.instancePath \ attr.name
                   )
                 )
@@ -110,7 +110,7 @@ object ObjectValidators {
           matchedPatternProperties.map(pp => {
             prop._1 -> pp._2.validate(prop._2, context.updateScope(
               _.copy(
-                schemaPath = context.schemaPath \ "properties" \ prop._1,
+                schemaJsPath = context.schemaPath.map(_ \ "properties" \ prop._1),
                 instancePath = context.instancePath \ prop._1
               )
             ))
@@ -136,7 +136,7 @@ object ObjectValidators {
           attr._2,
           context.updateScope(
             _.copy(
-              schemaPath = context.schemaPath \ Keywords.Object.AdditionalProperties,
+              schemaJsPath = context.schemaPath.map(_ \ Keywords.Object.AdditionalProperties),
               instancePath = context.instancePath \ attr._1
             )
           )
@@ -189,7 +189,7 @@ object ObjectValidators {
           Keywords.Object.Dependencies,
           Messages("obj.missing.prop.dep", prop),
           context.updateScope(_.copy(
-            schemaPath = context.schemaPath \ prop,
+            schemaJsPath = context.schemaPath.map(_ \ prop),
             instancePath = context.instancePath \ prop
           )),
           json

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/TupleValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/TupleValidators.scala
@@ -65,7 +65,7 @@ object TupleValidators {
               values(idx),
               context.updateScope(
                 _.copy(
-                  schemaPath = context.schemaPath \ idx.toString,
+                  schemaJsPath = context.schemaPath.map(_ \ idx.toString),
                   instancePath = context.instancePath \ idx.toString
                 )
               )
@@ -77,7 +77,7 @@ object TupleValidators {
                 jsValue,
                 context.updateScope(
                   _.copy(
-                    schemaPath = context.schemaPath \ idx.toString,
+                    schemaJsPath = context.schemaPath.map(_ \ idx.toString),
                     instancePath = context.instancePath \ idx.toString
                   )
                 )
@@ -93,7 +93,7 @@ object TupleValidators {
           jsValue,
           context.updateScope(
             _.copy(
-              schemaPath = context.schemaPath \ idx.toString,
+              schemaJsPath = context.schemaPath.map(p => p \ idx.toString),
               instancePath = context.instancePath \ idx.toString
             )
           )

--- a/src/test/scala/com/eclipsesource/schema/DefinitionsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/DefinitionsSpec.scala
@@ -14,9 +14,7 @@ class DefinitionsSpec extends Specification with JsonSpec { self =>
 
   "validate draft7" in {
     import Version7._
-    val jsonSchema = JsonSource.schemaFromStream(self.getClass.getResourceAsStream("/refs/json-schema-draft-07.json")).get
     implicit val validator: SchemaValidator = SchemaValidator(Some(Version7))
-      .addSchema("http://json-schema.org/draft-07/schema", jsonSchema)
     validate("definitions", "draft7")
   }
 

--- a/src/test/scala/com/eclipsesource/schema/ErrorHelper.scala
+++ b/src/test/scala/com/eclipsesource/schema/ErrorHelper.scala
@@ -1,0 +1,12 @@
+package com.eclipsesource.schema
+
+import play.api.libs.json._
+
+trait ErrorHelper {
+
+  def firstErrorOf[A](res: JsResult[A]): String = {
+    val errors: Seq[(JsPath, Seq[JsonValidationError])] = res.asEither.left.get
+    val firstError: JsValue = errors.toJson(0)
+    (firstError \ "msgs").get.as[JsArray].head.as[String]
+  }
+}

--- a/src/test/scala/com/eclipsesource/schema/RefRemoteDraft7Spec.scala
+++ b/src/test/scala/com/eclipsesource/schema/RefRemoteDraft7Spec.scala
@@ -8,7 +8,7 @@ class RefRemoteDraft7Spec extends Specification with JsonSpec {
 
   import Version7._
 
-  implicit val validator = SchemaValidator(Some(Version7))
+  implicit val validator: SchemaValidator = SchemaValidator(Some(Version7))
     .addSchema(
       "http://localhost:1234/integer.json",
       JsonSource.schemaFromStream(

--- a/src/test/scala/com/eclipsesource/schema/RefRemoteSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/RefRemoteSpec.scala
@@ -53,7 +53,6 @@ class RefRemoteSpec extends Specification with JsonSpec { self =>
     result.isError must beTrue
   }
 
-
   "ref within remote ref - ref within ref invalid" in {
     import Version4._
     val resourceUrl: URL = self.getClass.getResource("/remotes/subSchemas.json")
@@ -71,7 +70,7 @@ class RefRemoteSpec extends Specification with JsonSpec { self =>
     result.isError must beTrue
   }
 
-  "change resolution scope - change scope ref invalid" in {
+  "change resolution scope - change scope ref invalid" in new WithServer(createApp, port = 1234) {
     import Version4._
     val schema = JsonSource.schemaFromString(
       """{
@@ -86,9 +85,9 @@ class RefRemoteSpec extends Specification with JsonSpec { self =>
     val result     = validator.validate(schema, instance)
     val errors     = result.asEither.left.get
     val firstError = errors.toJson(0)
+    result.isError must beTrue
     (firstError \ "resolutionScope").get.as[String] must beEqualTo("http://localhost:1234/folder/")
     (firstError \ "msgs").get.as[JsArray].value.head.as[String] must beEqualTo("Could not resolve ref folderInteger.json.")
-    result.isError must beTrue
   }
 
   "change resolution scope - change scope ref invalid" in {

--- a/src/test/scala/com/eclipsesource/schema/ReferenceSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/ReferenceSpec.scala
@@ -16,9 +16,7 @@ class ReferenceSpec extends Specification with JsonSpec { self =>
 
   "validate draft7" in {
     import Version7._
-    val jsonSchema = JsonSource.schemaFromStream(self.getClass.getResourceAsStream("/refs/json-schema-draft-07.json")).get
     implicit val validator: SchemaValidator = SchemaValidator(Some(Version7))
-      .addSchema("http://json-schema.org/draft-07/schema", jsonSchema)
     validate("ref", "draft7")
   }
 

--- a/src/test/scala/com/eclipsesource/schema/SchemaValidatorSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/SchemaValidatorSpec.scala
@@ -2,7 +2,8 @@ package com.eclipsesource.schema
 
 import java.net.URL
 
-import com.eclipsesource.schema.drafts.Version4
+import com.eclipsesource.schema.drafts.Version7
+import com.eclipsesource.schema.internal.validators.DefaultFormats
 import com.eclipsesource.schema.test.Assets
 import play.api.Application
 import play.api.inject.guice.GuiceApplicationBuilder
@@ -12,11 +13,11 @@ import play.api.test.{PlaySpecification, WithServer}
 
 import scala.io.Source
 
-class SchemaValidatorSpec extends PlaySpecification { self =>
+class SchemaValidatorSpec extends PlaySpecification with ErrorHelper { self =>
 
   def createApp: Application = new GuiceApplicationBuilder().routes(Assets.routes(getClass)).build()
 
-  import Version4._
+  import Version7._
 
   val schema: SchemaType = JsonSource.schemaFromString(
     """{
@@ -44,14 +45,20 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
   val talkWrites: OWrites[Talk] = Json.writes[Talk]
   implicit val talkFormat: OFormat[Talk] = Json.format[Talk]
 
-  val resourceUrl: URL = getClass.getResource("/talk.json")
+  val talkUrl: URL = getClass.getResource("/talk.json")
   val instance: JsObject = Json.obj(
     "location" -> Json.obj(
       "name" -> "Munich"
     )
   )
 
-  "SchemaValidator(Some(Version4))" should {
+  private val locationSchema = JsonSource.schemaFromUrl(self.getClass.getResource("/location.json")).get
+
+  private val validator = SchemaValidator(Some(Version7))
+    .addSchema("location.json", locationSchema)
+    .addSchema("http://json-schema.org/geo", JsonSource.schemaFromUrl(self.getClass.getResource("/geo")).get)
+
+  "SchemaValidator" should {
 
     "validate additionalProperties schema constraint via $ref" in {
 
@@ -68,10 +75,10 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
       val valid = Json.obj("title" -> "This is valid")
       val invalid = Json.obj("title" -> "Too short")
 
-      val validator = SchemaValidator(Some(Version4))
+      val v = validator
         .addSchema("http://localhost:1234/talk.json", talkSchema)
-      validator.validate(schema, valid).isSuccess must beTrue
-      validator.validate(schema, invalid).isError must beTrue
+      v.validate(schema, valid).isSuccess must beTrue
+      v.validate(schema, invalid).isError must beTrue
     }
 
     "return unaltered validated array" in {
@@ -80,17 +87,14 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
           |  "type": "array",
           |  "items": { "type": "integer" }
           |}""".stripMargin).get
-      val result = SchemaValidator(Some(Version4)).validate(schema)(Json.arr(1, 2, 3))
+      val result = validator.validate(schema)(Json.arr(1, 2, 3))
       result.asOpt must beSome.which {
         case JsArray(seq) => seq must haveLength(3)
       }
     }
 
     "validate oneOf constraint via $ref" in {
-      val talkSchema = JsonSource.schemaFromStream(
-        self.getClass.getResourceAsStream("/talk.json")
-      ).get
-
+      val talkSchema = JsonSource.schemaFromUrl(talkUrl).get
       val schema = JsonSource.schemaFromString(
         """{
           |  "oneOf": [{ "$ref": "http://localhost:1234/talk.json#/properties/title" }]
@@ -99,43 +103,38 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
       val valid = JsString("Valid instance")
       val invalid = JsString("Too short")
 
-      val validator = SchemaValidator(Some(Version4))
+      val v = validator
         .addSchema("http://localhost:1234/talk.json", talkSchema)
-      validator.validate(schema, valid).isSuccess must beTrue
-      validator.validate(schema, invalid).isError must beTrue
+      v.validate(schema, valid).isSuccess must beTrue
+      v.validate(schema, invalid).isError must beTrue
     }
 
     "be validated via file based resource URL" in {
-      SchemaValidator(Some(Version4)).validate(resourceUrl)(instance).isSuccess must beTrue
+      val res = validator.validate(talkUrl)(instance)
+      res.isSuccess must beTrue
     }
 
     "validate via file based URL and Reads" in {
-      val geoSchema: SchemaType = JsonSource.schemaFromStream(self.getClass.getResourceAsStream("/geo")).get
-      val result: JsResult[Talk] = SchemaValidator(Some(Version4))
-        .addSchema("http://json-schema.org/geo", geoSchema)
-        .validate(resourceUrl, instance, talkReads)
+      val result: JsResult[Talk] = validator.validate(talkUrl, instance, talkReads)
       result.isSuccess must beTrue
       result.asOpt must beSome.which(talk => talk.location.name must beEqualTo("Munich"))
     }
 
     "validate via file based URL and Writes" in {
       val talk = Talk(Location("Munich"))
-      val result = SchemaValidator(Some(Version4)).validate(resourceUrl, talk, talkWrites)
+      val result = validator.validate(talkUrl, talk, talkWrites)
       result.isSuccess must beTrue
     }
 
     "validate via file based URL and Format" in {
       val talk = Talk(Location("Munich"))
-      val result: JsResult[Talk] = SchemaValidator(Some(Version4)).validate(resourceUrl, talk)
+      val result: JsResult[Talk] = validator.validate(talkUrl, talk)
       result.isSuccess must beTrue
       result.asOpt must beSome.which(talk => talk.location.name must beEqualTo("Munich"))
     }
 
     "validate with Reads" in {
-      val locationSchema = JsonSource.schemaFromStream(
-        self.getClass.getResourceAsStream("/location.json")
-      ).get
-      val result = SchemaValidator(Some(Version4))
+      val result = validator
         .addSchema("http://localhost:1234/location.json", locationSchema)
         .validate(schema, instance, talkReads)
       result.isSuccess must beTrue
@@ -143,13 +142,8 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     }
 
     "validate with Writes" in {
-      val locationSchema = JsonSource.schemaFromStream(
-        self.getClass.getResourceAsStream("/location.json")
-      ).get
       val talk = Talk(Location("Munich"))
-      val result = SchemaValidator(Some(Version4))
-        .addSchema("http://localhost:1234/location.json", locationSchema)
-        .validate(schema, talk, talkWrites)
+      val result = validator.validate(schema, talk, talkWrites)
       result.isSuccess must beTrue
     }
   }
@@ -157,14 +151,11 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
   "Remote ref" should {
     "validate" in new WithServer(app = createApp, port = 1234) {
       val resourceUrl: URL = new URL("http://localhost:1234/talk.json")
-      SchemaValidator(Some(Version4)).validate(resourceUrl)(instance).isSuccess must beTrue
+      validator.validate(resourceUrl)(instance).isSuccess must beTrue
     }
   }
 
   "report errors for wrong reads" in {
-    val locationSchema = JsonSource.schemaFromStream(
-      self.getClass.getResourceAsStream("/location.json")
-    ).get
     case class Foo(location: Location, title: String)
 
     val lr: Reads[Foo] = (
@@ -179,24 +170,20 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
       ),
       "title" -> "Some title"
     )
-    val result: JsResult[Foo] = SchemaValidator(Some(Version4))
-      .addSchema("http://localhost:1234/location.json", locationSchema)
-      .validate(schema, fooInstance, lr)
+    val result: JsResult[Foo] = validator.validate(schema, fooInstance, lr)
+    result.isError must beTrue
     result.asEither must beLeft.which {
       _.head._2.head.message must beEqualTo("error.path.missing")
     }
-    result.isError must beTrue
   }
 
   "should fail with message in case a ref can not be resolved" in {
     val schema = JsonSource.schemaFromString(
       """{ "$ref": "#/does/not/exist" }""".stripMargin).get
     val instance = JsNumber(42)
-    val result = SchemaValidator(Some(Version4)).validate(schema, instance)
+    val result = validator.validate(schema, instance)
     result.isError must beTrue
-    result.asEither must beLeft.which { _.head._2.head.message must beEqualTo(
-      """Could not resolve ref #/does/not/exist."""
-    )}
+    firstErrorOf(result) must beEqualTo("Could not resolve ref #/does/not/exist.")
   }
 
   "validate object with arbitrary properties of type string" in {
@@ -210,7 +197,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
         |    }
         | }
         |}""".stripMargin).get
-    val validator = SchemaValidator(Some(Version4))
+    val validator = SchemaValidator(Some(Version7))
 
     validator.validate(schema,
       Json.obj(
@@ -249,7 +236,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
         |    }
         |  }
         |}""".stripMargin).get
-    val validator = SchemaValidator(Some(Version4))
+    val validator = SchemaValidator(Some(Version7))
 
     validator.validate(schema,
       Json.obj(
@@ -314,7 +301,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
                    |    ]
                    |}
                  """.stripMargin
-    val validator = SchemaValidator(Some(Version4))
+    val validator = SchemaValidator(Some(Version7))
 
     // invalid since empty object matches no schema
     validator.validate(Source.fromString(schema), Json.obj()) must beLike {
@@ -333,18 +320,18 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     validator.validate(Source.fromString(schema), Json.obj("name2" -> "bar")).isSuccess must beTrue
 
     // invalid because not listed in enum
-    SchemaValidator(Some(Version4)).validate(Source.fromString(schema), Json.obj("name" -> "quux")).isError must beTrue
+    SchemaValidator(Some(Version7)).validate(Source.fromString(schema), Json.obj("name" -> "quux")).isError must beTrue
   }
 
   "verify cache hit (issue #98)" in {
     val talk = Talk(Location("Munich"))
-    val validator = SchemaValidator(Some(Version4))
-    validator.validate(resourceUrl, talk)
+    val validator = SchemaValidator(Some(Version7))
+    validator.validate(talkUrl, talk)
     validator.cache.mapping.isEmpty must beFalse
   }
 
   "add dependencies via addSchema and validate (#98)" in {
-    val validator = SchemaValidator(Some(Version4))
+    val validator = SchemaValidator(Some(Version7))
     val commonSchema = JsonSource.schemaFromString(
       """|{
          |  "definitions": {
@@ -376,7 +363,7 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
   }
 
   "add dependencies via addSchema and fail (#98)" in {
-    val validator = SchemaValidator(Some(Version4))
+    val validator = SchemaValidator(Some(Version7))
     val commonSchema = JsonSource.schemaFromString(
       """|{
          |  "definitions": {
@@ -413,11 +400,14 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
     result.isSuccess must beFalse
   }
 
-  "resolve additionalProperties constraint" in new WithServer(app = createApp, port = 1234) {
-    val validator = SchemaValidator(Some(Version4))
+  "resolve relative date.json reference via external reference" in new WithServer(app = createApp, port = 1234) {
+    val validator = SchemaValidator(Some(Version7(new SchemaConfigOptions {
+      override def supportsExternalReferences: Boolean = true
+      override def formats: Map[String, SchemaFormat] = DefaultFormats.formats
+    })))
     private val schema = JsonSource.schemaFromString(
       """{
-        |"id": "http://localhost:1234/talk.json#",
+        |"$id": "http://localhost:1234/talk.json#",
         |"definitions": {
         |  "foo": {
         |    "id": "schema1",
@@ -432,15 +422,15 @@ class SchemaValidatorSpec extends PlaySpecification { self =>
         |}""".
         stripMargin).get
 
-    validator.validate(schema,
-      Json.obj(
-        "foo" -> JsNumber(2015)
-      )
+    validator.validate(
+      schema,
+      Json.obj("foo" -> JsNumber(2015))
     ).isSuccess must beTrue
 
-    validator.validate(schema,
-      Json.obj("foo"
-        -> JsString("foo"))
-    ).isError must beTrue
+    val res: JsResult[JsObject] = validator.validate(
+      schema,
+      Json.obj("foo" -> JsString("foo"))
+    )
+    firstErrorOf(res) must beEqualTo("Wrong type. Expected integer, was string.")
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/UrlHandlerSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/UrlHandlerSpec.scala
@@ -1,13 +1,12 @@
 package com.eclipsesource.schema
 
-import java.net.{URL, URLConnection, URLStreamHandler}
-
-import com.eclipsesource.schema.drafts.Version4
+import com.eclipsesource.schema.drafts.{Version4, Version7}
+import com.eclipsesource.schema.internal.validators.DefaultFormats
 import com.eclipsesource.schema.urlhandlers.ClasspathUrlHandler
 import org.specs2.mutable.Specification
 import play.api.libs.json.Json
 
-class UrlHandlerSpec extends Specification {
+class UrlHandlerSpec extends Specification with ErrorHelper { self =>
 
   "UrlHandlers" should {
 
@@ -33,56 +32,38 @@ class UrlHandlerSpec extends Specification {
       result.isSuccess must beTrue
     }
 
-    // no relative protocol-ful handler registered, should fail
-    "should resolve protocol-ful relative references on the classpath with ClasspathUrlProtocolHandler (invalid instance)" in {
-      val validator = SchemaValidator(Some(Version4))
-      val url = clazz.getResource("/schemas/my-schema-with-protocol-ful-relative-path.schema")
-      validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> "Munich")))
-         .isError must beTrue
+    "should resolve absolute references on classpath with ClasspathUrlProtocolHandler (version 7)" in {
+      import Version7._
+      val validator = SchemaValidator(Some(Version7(new SchemaConfigOptions {
+        override def formats: Map[String, SchemaFormat] = DefaultFormats.formats
+        override def supportsExternalReferences: Boolean = true
+      }))).addUrlHandler(new ClasspathUrlHandler(), ClasspathUrlHandler.Scheme)
+      val schema = JsonSource.schemaFromString(
+        """{
+          |  "type": "object",
+          |  "properties": {
+          |     "schema": {
+          |        "$ref": "classpath:///refs/json-schema-draft-07.json"
+          |     }
+          |  }
+          |}
+        """.stripMargin)
+      val result = validator.validate(schema.get, Json.obj("schema" -> Json.obj()))
+      result.isSuccess must beTrue
     }
 
-    // if no URL handlers have been registered the default ones will be used
-    "should resolve protocol-less relative references on the classpath via default behaviour (valid instance)" in {
+    "should resolve relative references on classpath (valid instance)" in {
       val validator = SchemaValidator(Some(Version4))
       val url = clazz.getResource("/schemas/my-schema-with-protocol-less-relative-path.schema")
       validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> "Munich")))
         .isSuccess must beTrue
     }
 
-    "should resolve protocol-less relative references on the classpath with via default behaviour (invalid instance)" in {
+    "should resolve relative references on the classpath (invalid instance)" in {
       val validator = SchemaValidator(Some(Version4))
       val url = clazz.getResource("/schemas/my-schema-with-protocol-less-relative-path.schema")
-      validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> 3)))
-        .isError must beTrue
-    }
-
-    // use custom URLStreamHandler in order to override default behaviour
-    // this URL handler just returns the foo.schema for any given url
-    class MyUrlHandler extends URLStreamHandler {
-      override def openConnection(url: URL): URLConnection = {
-        clazz.getResource("/issue-65/schemas/foo.schema").openConnection()
-      }
-    }
-
-    "should resolve protocol-less relative references on the classpath with custom relative URL handler (valid instance)" in {
-      val validator = SchemaValidator(Some(Version4)).addRelativeUrlHandler(new MyUrlHandler)
-      val url = clazz.getResource("/issue-65/schemas/my-schema-with-protocol-less-relative-path.schema")
-      val result = validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> "Munich")))
-      result.isSuccess must beTrue
-    }
-
-    "should resolve protocol-less relative references on the classpath with custom relative URL handler (invalid instance)" in {
-      val validator = SchemaValidator(Some(Version4)).addRelativeUrlHandler(new MyUrlHandler)
-      val url = clazz.getResource("/issue-65/schemas/my-schema-with-protocol-less-relative-path.schema")
-      val invalidResult = validator.validate(url)(Json.obj("quux" -> Json.obj("bar" -> 3)))
-      invalidResult.isError must beTrue
-    }
-
-    "should fail resolving protocol-less relative references on the classpath if no relative URL handler registered" in {
-      val validator = SchemaValidator(Some(Version4))
-      val url = clazz.getResource("/issue-65/schemas/my-schema-with-protocol-less-relative-path.schema")
-      validator.validate(url)(Json.obj("quux" -> "Munich"))
-        .isError must beTrue
+      val res = validator.validate(url)(Json.obj("foo" -> Json.obj("bar" -> 3)))
+      firstErrorOf(res) must beEqualTo("Wrong type. Expected string, was number.")
     }
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/internal/refs/DraftExamplesSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/refs/DraftExamplesSpec.scala
@@ -10,7 +10,7 @@ class DraftExamplesSpec extends Specification {
 
   import Version4._
 
-  "Example from draft 4 - section7.2.2" should {
+  "Example from draft 4 - section 7.2.2" should {
 
     val schema = JsonSource.schemaFromString(
       """{
@@ -43,7 +43,7 @@ class DraftExamplesSpec extends Specification {
     }
 
     "infer correct resolution scope within schema1" in {
-      resolver.resolveFromRoot("#/schema1/id", scope) must beRight.which(
+      resolver.resolveFromRoot("#/schema1", scope) must beRight.which(
         _.scope.id.contains(Ref("http://x.y.z/rootschema.json#foo"))
       )
     }
@@ -55,19 +55,19 @@ class DraftExamplesSpec extends Specification {
     }
 
     "infer correct resolution scope within schema2/nested" in {
-      resolver.resolveFromRoot("#/schema2/nested/id", scope) must beRight.which(
+      resolver.resolveFromRoot("#/schema2/nested", scope) must beRight.which(
         _.scope.id.contains(Ref("http://x.y.z/otherschema.json#bar"))
       )
     }
 
     "infer correct resolution scope within schema2/alsonested" in {
-      resolver.resolveFromRoot("#/schema2/alsonested/id", scope) must beRight.which(
+      resolver.resolveFromRoot("#/schema2/alsonested", scope) must beRight.which(
         _.scope.id.contains(Ref("http://x.y.z/t/inner.json#a"))
       )
     }
 
     "infer correct resolution scope within schema3" in {
-      resolver.resolveFromRoot("#/schema3/id", scope) must beRight.which(
+      resolver.resolveFromRoot("#/schema3", scope) must beRight.which(
         _.scope.id.contains(Ref("some://where.else/completely#"))
       )
     }

--- a/src/test/scala/com/eclipsesource/schema/internal/refs/ResolveAnyConstraintsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/refs/ResolveAnyConstraintsSpec.scala
@@ -34,7 +34,8 @@ class ResolveAnyConstraintsSpec extends Specification { self =>
 
     val resolver = SchemaRefResolver(Version4)
       .copy(cache = DocumentCache()
-        .add(Ref("http://localhost:1234/talk.json"))(talkSchema)
+        .add(Ref(Version4.SchemaUrl))(Version4.Schema)
+        .add(Ref("http://localhost:1234/talk.json#"))(talkSchema)
       )
 
     "resolve oneOf constraint" in {
@@ -100,8 +101,8 @@ class ResolveAnyConstraintsSpec extends Specification { self =>
       val scope = SchemaResolutionScope(schema)
       val arrayDef = resolver.resolveFromRoot("#/definitions/schemaArray", scope)
       val anyOf = resolver.resolveFromRoot("#/properties/anyOf", scope)
-      anyOf.map(_.resolved) must beRight[SchemaType].which(_.isInstanceOf[SchemaArray])
       arrayDef.map(_.resolved) must beRight[SchemaType].which(_.isInstanceOf[SchemaArray])
+      anyOf.map(_.resolved) must beRight[SchemaType].which(_.isInstanceOf[SchemaArray])
     }
 
     "resolve definitions constraint" in {
@@ -167,7 +168,8 @@ class ResolveAnyConstraintsSpec extends Specification { self =>
         def formats: Map[String, SchemaFormat] = DefaultFormats.formats
       }))
       .copy(cache = DocumentCache()
-        .add(Ref("http://localhost:1234/talk.json"))(talkSchema)
+        .add(Ref(Version7.SchemaUrl))(JsonSource.schemaFromUrl(self.getClass.getResource("/json-schema-draft-07.json")).get)
+        .add(Ref("http://localhost:1234/talk.json#"))(talkSchema)
       )
 
     "resolve oneOf constraint" in {

--- a/src/test/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolverSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolverSpec.scala
@@ -1,25 +1,36 @@
 package com.eclipsesource.schema.internal.refs
 
 import com.eclipsesource.schema._
-import com.eclipsesource.schema.drafts.Version4
+import com.eclipsesource.schema.drafts.{Version4, Version7}
 import com.eclipsesource.schema.internal.draft4.constraints.{ArrayConstraints4, ObjectConstraints4}
-import com.eclipsesource.schema.test.Assets
+import com.eclipsesource.schema.internal._
 import com.osinka.i18n.Lang
 import org.specs2.mutable.Specification
-import play.api.Application
-import play.api.inject.guice.GuiceApplicationBuilder
 import play.api.libs.json._
 
 class SchemaRefResolverSpec extends Specification { self =>
 
-  import Version4._
+  def getResolved(e: Either[JsonValidationError, ResolvedResult]): SchemaType = {
+    e.right.get.resolved
+  }
 
-  def createApp: Application = new GuiceApplicationBuilder()
-    .routes(Assets.routes(getClass)).build()
+  def scopeId(e: Either[JsonValidationError, ResolvedResult]): Option[Ref] = {
+    e.right.get.scope.id
+  }
 
-  val resolver = SchemaRefResolver(Version4)
+  def schemaPath(e: Either[JsonValidationError, ResolvedResult]): Option[String] = {
+    e.right.get.scope.schemaPath
+  }
 
-  "SchemaRefResolver" should {
+
+  "SchemaRefResolver version 4" should {
+    import Version4._
+
+    val resolver = SchemaRefResolver(Version4,
+      DocumentCache().add(
+        Ref(Version4.SchemaUrl)
+      )(JsonSource.schemaFromUrl(self.getClass.getResource("/json-schema-draft-04.json")).get)
+    )
 
     "resolve references into JSON schema v4 draft" in {
       val schema = JsonSource.schemaFromString(
@@ -101,7 +112,130 @@ class SchemaRefResolverSpec extends Specification { self =>
       // scope and schema do not matter in this test
       implicit val lang: Lang = Lang.Default
       val result = resolver.resolveLocal(Nil, SchemaResolutionScope(schema), schema)
-      result.toEither must beRight.which(_.resolved == schema )
+      result.toEither must beRight.which(_.resolved == schema)
+    }
+  }
+
+  "SchemaRefResolver version 7 - section 8.2.4" should {
+
+    import Version7._
+    val schema = JsonSource.schemaFromString("""
+                                               |{
+                                               |  "$id": "http://example.com/root.json",
+                                               |  "definitions": {
+                                               |    "A": { "$id": "#foo" },
+                                               |    "B": {
+                                               |      "$id": "other.json",
+                                               |      "definitions": {
+                                               |        "X": { "$id": "#bar" },
+                                               |        "Y": { "$id": "t/inner.json" }
+                                               |      }
+                                               |    },
+                                               |    "C": {
+                                               |      "$id": "urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f"
+                                               |    }
+                                               |  }
+                                               |}""".stripMargin
+    ).get
+
+    val resolver = SchemaRefResolver(
+      Version7,
+      DocumentCache().addAll(collectSchemas(schema, Some(Ref("http://example.com/root.json"))))
+    )
+    val scope = SchemaResolutionScope(schema)
+
+    "document root" in {
+      val a = resolver.resolveFromRoot("http://example.com/root.json", scope)
+      val b = resolver.resolveFromRoot("http://example.com/root.json#", scope)
+      a.isRight must beTrue
+      b.isRight must beTrue
+
+      getResolved(a) must beEqualTo(getResolved(b))
+    }
+
+    "#/definitions/A" in {
+
+      val a = resolver.resolveFromRoot("http://example.com/root.json#foo", scope)
+      val b = resolver.resolveFromRoot("http://example.com/root.json#/definitions/A", scope)
+
+      a.isRight must beTrue
+      b.isRight must beTrue
+      getResolved(a) must beEqualTo(getResolved(b))
+
+      scopeId(a) must beSome(Ref("http://example.com/root.json#foo"))
+      schemaPath(a) must beNone
+
+      schemaPath(b) must beNone
+      scopeId(b) must beSome(Ref("http://example.com/root.json#foo"))
+    }
+
+    "#/definitions/B" in {
+      val a = resolver.resolveFromRoot("http://example.com/other.json", scope)
+      val b = resolver.resolveFromRoot("http://example.com/other.json#", scope)
+      val c = resolver.resolveFromRoot("http://example.com/root.json#/definitions/B", scope)
+
+      a.isRight must beTrue
+      b.isRight must beTrue
+      c.isRight must beTrue
+
+      getResolved(a) must beEqualTo(getResolved(b))
+      getResolved(b) must beEqualTo(getResolved(c))
+
+      scopeId(a) must beSome(Ref("http://example.com/other.json"))
+      schemaPath(a) must beNone
+
+      scopeId(b) must beSome(Ref("http://example.com/other.json"))
+      schemaPath(b) must beSome("#")
+
+      scopeId(c) must beSome(Ref("http://example.com/other.json"))
+      //      schemaPath(c) must beSome("#/definitions/B")
+      schemaPath(c) must beNone
+    }
+
+    "#/definitions/B/definitions/X" in {
+      val a = resolver.resolveFromRoot("http://example.com/other.json#bar", scope)
+      val b = resolver.resolveFromRoot("http://example.com/other.json#/definitions/X", scope)
+      val c = resolver.resolveFromRoot("http://example.com/root.json#/definitions/B/definitions/X", scope)
+
+      a.isRight must beTrue
+      b.isRight must beTrue
+      c.isRight must beTrue
+
+      getResolved(a) must beEqualTo(getResolved(b))
+      getResolved(b) must beEqualTo(getResolved(c))
+
+      scopeId(a) must beSome(Ref("http://example.com/other.json#bar"))
+      schemaPath(a) must beNone
+
+      scopeId(b) must beSome(Ref("http://example.com/other.json#bar"))
+      schemaPath(b) must beNone
+
+      scopeId(c) must beSome(Ref("http://example.com/other.json#bar"))
+      schemaPath(c) must beNone
+    }
+
+    "#/definitions/B/definitions/Y" in {
+      val a = resolver.resolveFromRoot("http://example.com/t/inner.json", scope)
+      val b = resolver.resolveFromRoot("http://example.com/t/inner.json#", scope)
+      val c = resolver.resolveFromRoot("http://example.com/other.json#/definitions/Y", scope)
+      val d = resolver.resolveFromRoot("http://example.com/root.json#/definitions/B/definitions/Y", scope)
+
+      getResolved(a) must beEqualTo(getResolved(b))
+      getResolved(b) must beEqualTo(getResolved(c))
+      getResolved(c) must beEqualTo(getResolved(d))
+    }
+
+    "#/definitions/C" in {
+      val a = resolver.resolveFromRoot("urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f", scope)
+      val b = resolver.resolveFromRoot("urn:uuid:ee564b8a-7a87-4125-8c96-e9f123d6766f#", scope)
+      val c = resolver.resolveFromRoot("http://example.com/root.json#/definitions/C", scope)
+
+      a.isRight must beTrue
+      b.isRight must beTrue
+      c.isRight must beTrue
+
+      getResolved(a) must beEqualTo(getResolved(b))
+      getResolved(b) must beEqualTo(getResolved(c))
     }
   }
 }

--- a/src/test/scala/com/eclipsesource/schema/internal/serialization/SchemaReadsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/serialization/SchemaReadsSpec.scala
@@ -3,6 +3,7 @@ package com.eclipsesource.schema.internal.serialization
 import com.eclipsesource.schema._
 import com.eclipsesource.schema.{JsonSource, SchemaType, SchemaValue}
 import com.eclipsesource.schema.drafts.{Version4, Version7}
+import com.eclipsesource.schema.internal.draft7.constraints.{AnyConstraints7, NumberConstraints7, StringConstraints7}
 import org.specs2.mutable.Specification
 import play.api.libs.json.{JsArray, JsBoolean, JsString, Json}
 
@@ -43,6 +44,23 @@ class SchemaReadsSpec extends Specification {
     "read boolean schema" in {
       val booleanSchema = Json.fromJson[SchemaType](JsBoolean(true)).get
       booleanSchema must beEqualTo(SchemaValue(JsBoolean(true)))
+    }
+
+    "read compound type with error" in {
+      val schema = JsonSource.schemaFromString("""
+                                                 |{
+                                                 |  "type": ["number", "string"]
+                                                 |}""".stripMargin)
+
+      schema.isSuccess must beTrue
+      schema.asOpt must beSome.which(
+        _ == CompoundSchemaType(
+          Seq(
+            SchemaNumber(NumberConstraints7().copy(any = AnyConstraints7().copy(schemaType = Some("number")))),
+            SchemaString(StringConstraints7().copy(any = AnyConstraints7().copy(schemaType = Some("string"))))
+          )
+        )
+      )
     }
   }
 }


### PR DESCRIPTION
Meta schemas are included by default now. Furthermore this PR includes the following changes:

* Make ref resolver treat absolute refs with # and without # at the end equivalent
* Make schemaPath of scope optional 
* Remove obsolete methods related to relative URL handlers
* Consolidate util functions for error creation and reporting