### PR TITLE
Fix merging of refs if both are plain name fragments

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/internal/refs/Ref.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/Ref.scala
@@ -31,6 +31,10 @@ object Refs {
         ).getOrElse(l)
 
       case r@RelativeRef(relativeRef) =>
+        if (relativeRef.startsWith("#") && currentScope.exists(_.value.startsWith("#"))) {
+          // both refs are plain name fragments, switch scope
+          ref
+        } else
         if (relativeRef.startsWith("#")) {
           // ref is plain name fragment
           currentScope.map(url =>

--- a/src/test/scala/com/eclipsesource/schema/internal/refs/RefsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/refs/RefsSpec.scala
@@ -10,6 +10,11 @@ class RefsSpec extends Specification {
     "should define resolution scopes" in {
 
       Refs.mergeRefs(
+        Ref("#foo"),
+        Some(Ref("#bar"))
+      ) must beEqualTo(Ref("#foo"))
+
+      Refs.mergeRefs(
         Ref("#"), Some(Ref("http://x.y.z/rootschema.json#"))
       ) must beEqualTo(Ref("http://x.y.z/rootschema.json#"))
 


### PR DESCRIPTION
The `resolutionScope` has not been determined correctly when given two refs which are both plain name fragments