### PR TITLE
Use resolved schema from cache as document root

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/internal/draft4/SchemaWrites4.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/draft4/SchemaWrites4.scala
@@ -1,11 +1,11 @@
 package com.eclipsesource.schema.internal.draft4
 
-import com.eclipsesource.schema.{SchemaArray, SchemaInteger, SchemaNumber, SchemaObject, SchemaString, SchemaTuple, SchemaVersion}
+import com.eclipsesource.schema.{SchemaArray, SchemaInteger, SchemaNumber, SchemaObject, SchemaRoot, SchemaString, SchemaTuple, SchemaVersion}
 import com.eclipsesource.schema.internal.Keywords
 import com.eclipsesource.schema.internal.constraints.Constraints._
 import com.eclipsesource.schema.internal.draft4.constraints._
 import com.eclipsesource.schema.internal.serialization.SchemaWrites
-import play.api.libs.json.{Json, OWrites}
+import play.api.libs.json.{Json, OWrites, Writes}
 
 trait SchemaWrites4 extends SchemaWrites { self: SchemaVersion =>
 
@@ -22,6 +22,7 @@ trait SchemaWrites4 extends SchemaWrites { self: SchemaVersion =>
         asJsObject(Keywords.Any.Not, not)
   }
 
+  override lazy val rootWrites: Writes[SchemaRoot] = Default.rootWrites
   override lazy val objectWrites: OWrites[SchemaObject] = Default.objectWrites(objectConstraintWrites)
   override lazy val stringWrites: OWrites[SchemaString] = Default.stringWrites(stringConstraintWrites)
   override lazy val integerWrites: OWrites[SchemaInteger] = Default.integerWrites(numberConstraintWrites)

--- a/src/main/scala/com/eclipsesource/schema/internal/draft7/SchemaWrites7.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/draft7/SchemaWrites7.scala
@@ -4,8 +4,8 @@ import com.eclipsesource.schema.internal.Keywords
 import com.eclipsesource.schema.internal.constraints.Constraints._
 import com.eclipsesource.schema.internal.draft7.constraints._
 import com.eclipsesource.schema.internal.serialization.SchemaWrites
-import com.eclipsesource.schema.{SchemaArray, SchemaInteger, SchemaNumber, SchemaObject, SchemaString, SchemaTuple, SchemaVersion}
-import play.api.libs.json.{Json, OWrites}
+import com.eclipsesource.schema.{SchemaArray, SchemaInteger, SchemaNumber, SchemaObject, SchemaRoot, SchemaString, SchemaTuple, SchemaVersion}
+import play.api.libs.json.{Json, OWrites, Writes}
 
 trait SchemaWrites7 extends SchemaWrites { self: SchemaVersion =>
 
@@ -26,6 +26,7 @@ trait SchemaWrites7 extends SchemaWrites { self: SchemaVersion =>
         asJsObject(Keywords.Any.Else, _else)
   }
 
+  override lazy val rootWrites: Writes[SchemaRoot] = Default.rootWrites
   override lazy val objectWrites: OWrites[SchemaObject] = Default.objectWrites(objectConstraintWrites)
   override lazy val stringWrites: OWrites[SchemaString] = Default.stringWrites(stringConstraintWrites)
   override lazy val integerWrites: OWrites[SchemaInteger] = Default.integerWrites(numberConstraintWrites)

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
@@ -88,13 +88,12 @@ case class SchemaRefResolver
 
           currentResolutionScope.collectFirst {
             case id if absoluteRef.startsWith(id.value) => absoluteRef.drop(id.value.length)
-          }.map(remaining => {
+          }.map(remaining =>
             resolve(
               current,
               Ref(if (remaining.startsWith("#")) remaining else "#" + remaining),
               updatedScope
             )
-          }
           ).getOrElse(resolveAbsolute(a, updatedScope))
 
         case r@RelativeRef(_) =>

--- a/src/main/scala/com/eclipsesource/schema/internal/serialization/SchemaWrites.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/serialization/SchemaWrites.scala
@@ -20,13 +20,15 @@ trait SchemaWrites { self: SchemaVersion =>
     case n: CompoundSchemaType => compoundWrites.writes(n)
     case s: SchemaMap          => schemaMapWriter.writes(s)
     case v: SchemaValue        => v.value
+    case r: SchemaRoot         => rootWrites.writes(r)
     case other => additionalWrites.writes(other)
   }
 
   def additionalWrites: OWrites[SchemaType] = OWrites[SchemaType](other =>
-    throw new RuntimeException(s"Unknown schema type encountered.\n$other")
+    throw new RuntimeException(s"Unknown schema type encountered: $other")
   )
   def anyConstraintWrites: OWrites[AnyConstraints]
+  def rootWrites: Writes[SchemaRoot]
   def stringWrites: OWrites[SchemaString]
   def numberWrites: OWrites[SchemaNumber]
   def integerWrites: OWrites[SchemaInteger]
@@ -75,6 +77,12 @@ trait SchemaWrites { self: SchemaVersion =>
   def emptyJsonObject: JsObject = Json.obj()
 
   object Default {
+
+    def rootWrites: Writes[SchemaRoot] =
+      Writes[SchemaRoot] { schemaRoot =>
+        Json.toJson(schemaRoot.schema)
+      }
+
     // TODO: default is missing
     def objectWrites(objectConstraintWrites: OWrites[ObjectConstraints]): OWrites[SchemaObject] =
       OWrites[SchemaObject] { schemaObj =>

--- a/src/test/resources/tincan/activity.json
+++ b/src/test/resources/tincan/activity.json
@@ -1,0 +1,12 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#activity",
+    "type": "object",
+    "required": ["id"],
+    "additionalProperties": false,
+    "properties": {
+        "objectType": {"enum": ["Activity"]},
+        "id": {"$ref": "#activityid!core"},
+        "definition": {"$ref": "#activity_definition"}
+    }
+}

--- a/src/test/resources/tincan/activity_definition.json
+++ b/src/test/resources/tincan/activity_definition.json
@@ -1,0 +1,40 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#activity_definition",
+    "type": "object",
+    "oneOf": [
+        {
+            "properties": {
+                "interactionType": {"type": "null"},
+                "correctResponsesPattern": {"type": "null"},
+                "choices": {"type": "null"},
+                "scale": {"type": "null"},
+                "source": {"type": "null"},
+                "target": {"type": "null"},
+                "steps": {"type": "null"}
+            }
+        },
+        {"$ref": "#interactionactivity"}
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "name": {"$ref": "#languagemap"},
+        "description": {"$ref": "#languagemap"},
+        "type": {
+            "type": "string",
+            "format": "iri"
+        },
+        "moreInfo": {
+            "type": "string",
+            "format": "iri"
+        },
+        "interactionType": {},
+        "correctResponsesPattern": {},
+        "choices": {},
+        "scale": {},
+        "source": {},
+        "target": {},
+        "steps": {},
+        "extensions": {"$ref": "#extensions"}
+    }
+}

--- a/src/test/resources/tincan/activityid.json
+++ b/src/test/resources/tincan/activityid.json
@@ -1,0 +1,13 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#activityid",
+    "type": "object",
+    "required": ["activityId"],
+    "properties": {
+        "activityId": {
+            "id": "#activityid!core",
+            "type": "string",
+            "format": "iri"
+        }
+    }
+}

--- a/src/test/resources/tincan/agent.json
+++ b/src/test/resources/tincan/agent.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#agent",
+    "allOf": [{"$ref": "#inversefunctional"}],
+    "properties": {
+        "name": {"type": "string"},
+        "objectType": {"enum": ["Agent"]},
+        "mbox": {},
+        "mbox_sha1sum": {},
+        "account": {},
+        "openid": {}
+    },
+    "additionalProperties": false
+}

--- a/src/test/resources/tincan/group.json
+++ b/src/test/resources/tincan/group.json
@@ -1,0 +1,8 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#group",
+    "oneOf": [
+        {"$ref": "#anonymousgroup"},
+        {"$ref": "#identifiedgroup"}
+    ]
+}

--- a/src/test/resources/tincan/inversefunctional.json
+++ b/src/test/resources/tincan/inversefunctional.json
@@ -1,0 +1,10 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#inversefunctional",
+    "oneOf": [
+        {"$ref": "#mbox"},
+        {"$ref": "#mbox_sha1sum"},
+        {"$ref": "#openid"},
+        {"$ref": "#account"}
+    ]
+}

--- a/src/test/resources/tincan/languagemap.json
+++ b/src/test/resources/tincan/languagemap.json
@@ -1,0 +1,11 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#languagemap",
+    "type": "object",
+    "patternProperties": {
+        "^(((([A-Za-z]{2,3}(-([A-Za-z]{3}(-[A-Za-z]{3}){0,2}))?)|[A-Za-z]{4}|[A-Za-z]{5,8})(-([A-Za-z]{4}))?(-([A-Za-z]{2}|[0-9]{3}))?(-([A-Za-z0-9]{5,8}|[0-9][A-Za-z0-9]{3}))*(-([0-9A-WY-Za-wy-z](-[A-Za-z0-9]{2,8})+))*(-(x(-[A-Za-z0-9]{1,8})+))?)|(x(-[A-Za-z0-9]{1,8})+)|((en-GB-oed|i-ami|i-bnn|i-default|i-enochian|i-hak|i-klingon|i-lux|i-mingo|i-navajo|i-pwn|i-tao|i-tay|i-tsu|sgn-BE-FR|sgn-BE-NL|sgn-CH-DE)|(art-lojban|cel-gaulish|no-bok|no-nyn|zh-guoyu|zh-hakka|zh-min|zh-min-nan|zh-xiang)))$": {
+            "type": "string"
+        }
+    },
+    "additionalProperties": false
+}

--- a/src/test/resources/tincan/mbox.json
+++ b/src/test/resources/tincan/mbox.json
@@ -1,0 +1,16 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#mbox",
+    "type": "object",
+    "required": ["mbox"],
+    "properties": {
+        "mbox": {
+            "id": "#mbox!core",
+            "type": "string",
+            "format": "mailto-iri"
+        },
+        "mbox_sha1sum": {"type": "null"},
+        "openid": {"type": "null"},
+        "account": {"type": "null"}
+    }
+}

--- a/src/test/resources/tincan/statement_base.json
+++ b/src/test/resources/tincan/statement_base.json
@@ -1,0 +1,73 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#statement_base",
+    "type": "object",
+    "required": ["actor", "verb", "object"],
+    "oneOf": [
+        {
+            "required": ["object"],
+            "properties": {
+                "object": {"$ref": "#activity"}
+            }
+        },
+        {
+            "required": ["object"],
+            "properties": {
+                "object": {"not": {"$ref": "#activity"}},
+                "context": {
+                    "properties": {
+                        "revision": {"type": "null"},
+                        "platform": {"type": "null"}
+                    }
+                }
+            }
+        }
+    ],
+    "additionalProperties": false,
+    "properties": {
+        "objectType": {},
+        "id": {
+            "type": "string",
+            "format": "uuid"
+        },
+        "actor": {
+            "oneOf": [
+                {"$ref": "#agent"},
+                {"$ref": "#group"}
+            ]
+        },
+        "verb": {"$ref": "#verb"},
+        "object": {"$ref": "#statement_object"},
+        "result": {"$ref": "#result"},
+        "context": {"$ref": "#context"},
+        "timestamp": {
+            "type": "string",
+            "format": "iso_date"
+        },
+        "stored": {
+            "type": "string",
+            "format": "iso_date"
+        },
+        "authority": {
+            "oneOf": [
+                {"$ref": "#agent"},
+                {
+                    "allOf": [{"$ref": "#anonymousgroup"}],
+                    "properties": {
+                        "member": {
+                            "type": "array",
+                            "items": {"$ref": "#agent"},
+                            "minItems": 2,
+                            "maxItems": 2
+                        }
+                    }
+                }
+            ]
+        },
+        "version": {"$ref": "#version"},
+        "attachments": {
+            "type": "array",
+            "items": {"$ref": "#attachment"}
+        }
+    }
+}

--- a/src/test/resources/tincan/statement_object.json
+++ b/src/test/resources/tincan/statement_object.json
@@ -1,0 +1,17 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#statement_object",
+    "type": "object",
+    "oneOf": [
+        {"$ref": "#activity"},
+        {
+            "required": ["objectType"],
+            "oneOf":[
+                {"$ref": "#agent"},
+                {"$ref": "#group"},
+                {"$ref": "#statementref"},
+                {"$ref": "#substatement"}
+            ]
+        }
+    ]
+}

--- a/src/test/resources/tincan/verb.json
+++ b/src/test/resources/tincan/verb.json
@@ -1,0 +1,14 @@
+{
+    "$schema": "http://json-schema.org/draft-04/schema#",
+    "id": "#verb",
+    "type": "object",
+    "required": ["id"],
+    "properties": {
+        "id": {
+            "type": "string",
+            "format": "iri"
+        },
+        "display": {"$ref": "#languagemap"}
+    },
+    "additionalProperties": false
+}

--- a/src/test/scala/com/eclipsesource/schema/TinCanSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/TinCanSpec.scala
@@ -1,0 +1,59 @@
+package com.eclipsesource.schema
+
+import org.specs2.mutable.Specification
+import play.api.libs.json.{JsValue, Json}
+
+import scala.util.Try
+
+class TinCanSpec extends Specification { self =>
+
+  import com.eclipsesource.schema.drafts.Version4
+
+  val instance = JsonSource.fromString(
+    """
+      |{
+      |  "actor": {
+      |    "name": "Sally Glider",
+      |    "mbox": "mailto:sally@example.com"
+      |  },
+      |  "verb": {
+      |    "id": "http://adlnet.gov/expapi/verbs/experienced",
+      |    "display": { "en-US": "experienced" }
+      |  },
+      |  "object": {
+      |    "id": "http://example.com/activities/solo-hang-gliding",
+      |    "definition": {
+      |      "name": { "en-US": "Solo Hang Gliding" }
+      |    }
+      |  }
+      |}
+    """.stripMargin).get
+
+
+  "Tin Can Spec" should {
+
+    import Version4._
+
+    def readSchema(filename: String) =
+      JsonSource.schemaFromStream(self.getClass.getResourceAsStream(s"/tincan/$filename.json")).get
+
+    "validate basic statement object" in {
+
+      val validator = SchemaValidator(Some(Version4))
+        .addSchema("#agent", readSchema("agent"))
+        .addSchema("#group", readSchema("group"))
+        .addSchema("#inversefunctional", readSchema("inversefunctional"))
+        .addSchema("#mbox", readSchema("mbox"))
+        .addSchema("#statement_base", readSchema("statement_base"))
+        .addSchema("#statement_object", readSchema("statement_object"))
+        .addSchema("#verb", readSchema("verb"))
+        .addSchema("#languagemap", readSchema("languagemap"))
+        .addSchema("#activity", readSchema("activity"))
+        .addSchema("#activity_definition", readSchema("activity_definition"))
+        .addSchema("#activityid", readSchema("activityid"))
+
+      val result = validator.validate(readSchema("statement_base"), instance)
+      result.isSuccess must beTrue
+    }
+  }
+}

--- a/src/test/scala/com/eclipsesource/schema/internal/refs/ResolveStringConstraintsSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/refs/ResolveStringConstraintsSpec.scala
@@ -35,7 +35,7 @@ class ResolveStringConstraintsSpec extends Specification {
   "draft v7" should {
 
     import Version7._
-    val resolver = SchemaRefResolver(Version4)
+    val resolver = SchemaRefResolver(Version7)
 
     "resolve string constraints" in {
       val schema =

--- a/src/test/scala/com/eclipsesource/schema/internal/serialization/SchemaWritesSpec.scala
+++ b/src/test/scala/com/eclipsesource/schema/internal/serialization/SchemaWritesSpec.scala
@@ -70,6 +70,14 @@ class SchemaWritesSpec extends Specification {
       )
     }
 
+    "write root" in {
+      Json.toJson(
+        SchemaRoot(Some(Version4), SchemaNumber(NumberConstraints4()))
+      ) must beEqualTo(
+          Json.obj("type" -> "number")
+      )
+    }
+
     "write array" in {
       Json.toJson(SchemaArray(SchemaNumber(NumberConstraints4()), ArrayConstraints4())) must beEqualTo(
         Json.obj("items" -> Json.obj("type" -> "number"))


### PR DESCRIPTION
When resolving a schema via the cache the document root of the current scope has not been updated properly