### PR TITLE
Provide default validation fallback messages

### DIFF
--- a/src/main/scala/com/eclipsesource/schema/SchemaValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/SchemaValidator.scala
@@ -7,7 +7,7 @@ import com.eclipsesource.schema.internal._
 import com.eclipsesource.schema.internal.refs.{DocumentCache, Ref, SchemaRefResolver, SchemaResolutionScope}
 import com.eclipsesource.schema.internal.url.UrlStreamResolverFactory
 import com.eclipsesource.schema.internal.validators.DefaultFormats
-import com.osinka.i18n.{Lang, Messages}
+import com.osinka.i18n.Lang
 import play.api.libs.json._
 import scalaz.\/
 
@@ -105,7 +105,7 @@ class SchemaValidator(
   private[schema] def readJson(json: JsValue)(implicit reads: Reads[SchemaType], lang: Lang): \/[JsonValidationError, SchemaType] = {
     \/.fromEither(Json.fromJson[SchemaType](json).asEither)
       .leftMap(errors =>
-        JsonValidationError(Messages("err.parse.json"), JsError.toJson(errors))
+        JsonValidationError(ValidatorMessages("err.parse.json"), JsError.toJson(errors))
       )
   }
 

--- a/src/main/scala/com/eclipsesource/schema/internal/ValidatorMessages.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/ValidatorMessages.scala
@@ -1,0 +1,62 @@
+package com.eclipsesource.schema.internal
+
+import java.text.MessageFormat
+
+import com.osinka.i18n.{Lang, Messages}
+
+import scala.util.Try
+
+object ValidatorMessages {
+
+  val DefaultMessages: Map[String, String] = Map(
+    "obj.missing.prop.dep" -> "Missing property dependency {0}.",
+    "obj.max.props" -> "Too many properties. {0} properties found, but only a maximum of {1} is allowed.",
+    "obj.min.props" -> "Found {0} properties, but a minimum of {1} is required.",
+    "obj.additional.props" -> "Additional properties are not allowed, but found properties {0}.",
+    "obj.required.prop" -> "Property {0} missing.",
+    "arr.max" -> "Too many items. {0} items found, but only a maximum of {1} is allowed.",
+    "arr.min" -> "Found {0} items, but a minimum of {1} is required.",
+    "arr.dups" -> "Found duplicates.",
+    "arr.out.of.bounds" -> "Array index {0} out of bounds.",
+    "arr.invalid.index" -> "Invalid array index {0}.",
+    "str.pattern" -> "''{0}'' does not match pattern ''{1}''.",
+    "str.invalid.pattern" -> "Invalid pattern ''{0}''.",
+    "str.min.length" -> "''{0}'' does not match minimum length of {1}.",
+    "str.max.length" -> "''{0}'' exceeds maximum length of {1}.",
+    "str.format" -> "''{0}'' does not match format {1}.",
+    "num.multiple.of" -> "{0} is not a multiple of {1}.",
+    "num.max" -> "{0} exceeds maximum value of {1}.",
+    "num.max.exclusive" -> "{0} exceeds exclusive maximum value of {1}.",
+    "num.min" -> "{0} is smaller than required minimum value of {1}.",
+    "num.min.exclusive" -> "{0} is smaller than required exclusive minimum value of {1}.",
+    "any.not" -> "Instance matches schema although it must not.",
+    "any.all" -> "Instance does not match all schemas.",
+    "any.any" -> "Instance does not match any of the schemas.",
+    "any.one.of.none" -> "Instance does not match any schema.",
+    "any.one.of.many" -> "Instance matches more than one schema.",
+    "any.enum" -> "Instance is invalid enum value.",
+    "any.const" -> "Instance does not match const value.",
+    "comp.no.schema" -> "No schema applicable.",
+    "err.expected.type" -> "Wrong type. Expected {0}, was {1}.",
+    "err.unresolved.ref" -> "Could not resolve ref {0}.",
+    "err.prop.not.found" -> "Could not find property {0}.",
+    "err.ref.expected" -> "Expected to find ref at {0}.",
+    "err.res.scope.id.empty" -> "Resolution scope ID must not be empty.",
+    "err.parse.json" -> "Could not parse JSON.",
+    "err.max.depth" -> "Maximum recursion depth reached.",
+    "err.dependencies.not.found" -> "Dependency not found.",
+    "err.definitions.not.found" -> "Definition not found.",
+    "err.patternProperties.not.found" -> "Pattern Properties not found.",
+    "err.false.schema" -> "Boolean false schema encountered.",
+    "err.contains" -> "Array does not contain valid item.",
+    "err.if.then.else" -> "Conditional validation failed."
+  )
+
+  def apply(msg: String, args: Any*)(implicit lang: Lang): String = {
+    Try(Messages(msg, args:_*))
+      .getOrElse(
+        new MessageFormat(DefaultMessages(msg)).format(args.map(_.asInstanceOf[java.lang.Object]).toArray)
+      )
+  }
+
+}

--- a/src/main/scala/com/eclipsesource/schema/internal/ValidatorMessages.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/ValidatorMessages.scala
@@ -55,7 +55,7 @@ object ValidatorMessages {
   def apply(msg: String, args: Any*)(implicit lang: Lang): String = {
     Try(Messages(msg, args:_*))
       .getOrElse(
-        new MessageFormat(DefaultMessages(msg)).format(args.map(_.asInstanceOf[java.lang.Object]).toArray)
+        new MessageFormat(DefaultMessages(msg)).format(args.map(_.asInstanceOf[Object]).toArray)
       )
   }
 

--- a/src/main/scala/com/eclipsesource/schema/internal/draft4/constraints/NumberConstraints4.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/draft4/constraints/NumberConstraints4.scala
@@ -1,10 +1,10 @@
 package com.eclipsesource.schema.internal.draft4.constraints
 
 import com.eclipsesource.schema.{SchemaInteger, SchemaNumber, SchemaResolutionContext, SchemaType, SchemaValue}
-import com.eclipsesource.schema.internal.{Keywords, SchemaUtil}
+import com.eclipsesource.schema.internal.{Keywords, SchemaUtil, ValidatorMessages}
 import com.eclipsesource.schema.internal.constraints.Constraints._
 import com.eclipsesource.schema.internal.validation.{Rule, VA}
-import com.osinka.i18n.{Lang, Messages}
+import com.osinka.i18n.Lang
 import play.api.libs.json.{JsNumber, JsString, JsValue}
 import scalaz.Success
 
@@ -34,7 +34,7 @@ case class NumberConstraints4(min: Option[Minimum] = None,
         case other =>
           SchemaUtil.failure(
             Keywords.Any.Type,
-            Messages("err.expected.type", "integer", SchemaUtil.typeOfAsString(other)),
+            ValidatorMessages("err.expected.type", "integer", SchemaUtil.typeOfAsString(other)),
             context.schemaPath,
             context.instancePath,
             other

--- a/src/main/scala/com/eclipsesource/schema/internal/draft7/constraints/NumberConstraints7.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/draft7/constraints/NumberConstraints7.scala
@@ -1,10 +1,10 @@
 package com.eclipsesource.schema.internal.draft7.constraints
 
 import com.eclipsesource.schema.{SchemaInteger, SchemaNumber, SchemaResolutionContext, SchemaType, SchemaValue}
-import com.eclipsesource.schema.internal.{Keywords, SchemaUtil}
+import com.eclipsesource.schema.internal.{Keywords, SchemaUtil, ValidatorMessages}
 import com.eclipsesource.schema.internal.constraints.Constraints._
 import com.eclipsesource.schema.internal.validation.{Rule, VA}
-import com.osinka.i18n.{Lang, Messages}
+import com.osinka.i18n.Lang
 import play.api.libs.json.{JsNumber, JsString, JsValue}
 import scalaz.Success
 
@@ -34,7 +34,7 @@ case class NumberConstraints7(min: Option[Minimum] = None,
         case other =>
           SchemaUtil.failure(
             Keywords.Any.Type,
-            Messages("err.expected.type", "integer", SchemaUtil.typeOfAsString(other)),
+            ValidatorMessages("err.expected.type", "integer", SchemaUtil.typeOfAsString(other)),
             context.schemaPath,
             context.instancePath,
             other

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
@@ -35,13 +35,13 @@ case class SchemaRefResolver
     * Update the resolution scope based on the current element.
     *
     * @param scope the current resolution scope
-    * @param a the value that might contain scope refinements
+    * @param schema the value that might contain scope refinements
     * @return the updated scope, if the given value contain a scope refinement, otherwise
     *         the not updated scope
     */
-  private[schema] def updateResolutionScope(scope: SchemaResolutionScope, a: SchemaType): SchemaResolutionScope = a match {
-    case _ if refinesScope(a) =>
-      val updatedId = findScopeRefinement(a).map(
+  private[schema] def updateResolutionScope(scope: SchemaResolutionScope, schema: SchemaType): SchemaResolutionScope = schema match {
+    case _ if refinesScope(schema) =>
+      val updatedId = findScopeRefinement(schema).map(
         id => Refs.mergeRefs(id, scope.id, Some(resolverFactory))
       )
       scope.copy(id = updatedId)

--- a/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/refs/SchemaRefResolver.scala
@@ -6,7 +6,7 @@ import com.eclipsesource.schema._
 import com.eclipsesource.schema.internal._
 import com.eclipsesource.schema.internal.constraints.Constraints.Constraint
 import com.eclipsesource.schema.internal.url.UrlStreamResolverFactory
-import com.osinka.i18n.{Lang, Messages}
+import com.osinka.i18n.Lang
 import play.api.libs.json._
 import scalaz.syntax.either._
 import scalaz.{\/, \/-}
@@ -65,7 +65,7 @@ case class SchemaRefResolver
     val updatedScope = updateResolutionScope(scope.copy(depth = scope.depth + 1), current)
 
     if (scope.depth >= MaxDepth) {
-      JsonValidationError(Messages("err.max.depth")).left
+      JsonValidationError(ValidatorMessages("err.max.depth")).left
     } else {
       val result: \/[JsonValidationError, ResolvedResult] = ref match {
 
@@ -112,7 +112,7 @@ case class SchemaRefResolver
     }
   }
   private[schema] def resolutionFailure(ref: Ref)(implicit lang: Lang): JsonValidationError =
-    JsonValidationError(Messages("err.unresolved.ref", ref.value))
+    JsonValidationError(ValidatorMessages("err.unresolved.ref", ref.value))
 
   private def resolveRelative(ref: RelativeRef, scope: SchemaResolutionScope, instance: SchemaType)
                              (implicit lang: Lang): \/[JsonValidationError, ResolvedResult] = {
@@ -201,7 +201,7 @@ case class SchemaRefResolver
         source <- if (url.getProtocol == null || version.options.supportsExternalReferences) {
           \/.fromEither(Try { Source.fromURL(url) }.toJsonEither)
         } else {
-          JsonValidationError(Messages("err.unresolved.ref")).left
+          JsonValidationError(ValidatorMessages("err.unresolved.ref")).left
         }
         read <- readSource(source)
       } yield {
@@ -217,7 +217,7 @@ case class SchemaRefResolver
 
   private[schema] def readJson(json: JsValue)(implicit lang: Lang): \/[JsonValidationError, SchemaType] = \/.fromEither(Json.fromJson[SchemaType](json).asEither)
     .leftMap(errors =>
-      JsonValidationError(Messages("err.parse.json"), JsError.toJson(errors))
+      JsonValidationError(ValidatorMessages("err.parse.json"), JsError.toJson(errors))
     )
 
   private[schema] def readSource(source: Source)(implicit lang: Lang): \/[JsonValidationError, SchemaType] = {
@@ -286,7 +286,7 @@ case class SchemaRefResolver
   private def resolveConstraint[A <: Constraint](constraints: A, constraint: String)
                                                 (implicit lang: Lang): Either[JsonValidationError, SchemaType] = {
     constraints.resolvePath(constraint).fold[Either[JsonValidationError, SchemaType]](
-      Left(JsonValidationError(Messages("err.unresolved.ref", constraint)))
+      Left(JsonValidationError(ValidatorMessages("err.unresolved.ref", constraint)))
     )(schema => Right(schema))
   }
 
@@ -294,14 +294,14 @@ case class SchemaRefResolver
                                  (implicit lang: Lang): Either[JsonValidationError, SchemaType] = {
     props.collectFirst {
       case SchemaProp(name, s) if name == propName => s
-    }.toRight(JsonValidationError(Messages("err.prop.not.found", propName)))
+    }.toRight(JsonValidationError(ValidatorMessages("err.prop.not.found", propName)))
   }
 
   private def findOtherProp(props: Seq[(String, SchemaType)], propName: String)
                                  (implicit lang: Lang): Either[JsonValidationError, SchemaType] = {
     props.collectFirst {
       case (name, s) if name == propName => s
-    }.toRight(JsonValidationError(Messages("err.prop.not.found", propName)))
+    }.toRight(JsonValidationError(ValidatorMessages("err.prop.not.found", propName)))
   }
 
 
@@ -317,7 +317,7 @@ case class SchemaRefResolver
     schema match {
 
       case SchemaMap(name, members) =>
-        members.find(_.name == fragmentPart).map(_.schemaType).toRight(JsonValidationError(Messages(s"err.$name.not.found")))
+        members.find(_.name == fragmentPart).map(_.schemaType).toRight(JsonValidationError(ValidatorMessages(s"err.$name.not.found")))
 
       case SchemaSeq(members) =>
         fragmentPart match {
@@ -355,9 +355,9 @@ case class SchemaRefResolver
           if (idx > 0 && idx < arr.value.size) {
             Right(SchemaValue(arr.value(idx)))
           } else {
-            Left(JsonValidationError(Messages("arr.out.of.bounds", index)))
+            Left(JsonValidationError(ValidatorMessages("arr.out.of.bounds", index)))
           }
-        case _ => Left(JsonValidationError(Messages("arr.invalid.index", fragmentPart)))
+        case _ => Left(JsonValidationError(ValidatorMessages("arr.invalid.index", fragmentPart)))
       }
 
       case CompoundSchemaType(alternatives) =>
@@ -366,7 +366,7 @@ case class SchemaRefResolver
         )
         results
           .collectFirst { case r@Right(_) => r }
-          .getOrElse(Left(JsonValidationError(Messages("err.unresolved.ref", fragmentPart))))
+          .getOrElse(Left(JsonValidationError(ValidatorMessages("err.unresolved.ref", fragmentPart))))
 
       case n: SchemaNumber => resolveConstraint(n.constraints, fragmentPart)
       case n: SchemaInteger => resolveConstraint(n.constraints, fragmentPart)

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/AnyConstraintValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/AnyConstraintValidators.scala
@@ -3,11 +3,11 @@ package com.eclipsesource.schema.internal.validators
 import com.eclipsesource.schema.internal._
 import com.eclipsesource.schema.internal.validation.{Rule, VA}
 import com.eclipsesource.schema.{SchemaObject, SchemaResolutionContext, SchemaType}
-import com.osinka.i18n.{Lang, Messages}
+import com.osinka.i18n.Lang
 import play.api.libs.json._
+import scalaz.{Failure, Success}
 
 import scala.annotation.tailrec
-import scalaz.{Failure, Success}
 
 object AnyConstraintValidators {
 
@@ -25,7 +25,7 @@ object AnyConstraintValidators {
             } else {
               SchemaUtil.failure(
                 "else",
-                Messages("err.if.then.else", json),
+                ValidatorMessages("err.if.then.else", json),
                 context.schemaPath,
                 context.instancePath,
                 json
@@ -40,7 +40,7 @@ object AnyConstraintValidators {
             } else {
               SchemaUtil.failure(
                 "then",
-                Messages("err.if.then.else", json),
+                ValidatorMessages("err.if.then.else", json),
                 context.schemaPath,
                 context.instancePath,
                 json
@@ -54,7 +54,7 @@ object AnyConstraintValidators {
             } else {
               SchemaUtil.failure(
                 "else",
-                Messages("err.if.then.else", json),
+                ValidatorMessages("err.if.then.else", json),
                 context.schemaPath,
                 context.instancePath,
                 json
@@ -75,7 +75,7 @@ object AnyConstraintValidators {
           } else {
             SchemaUtil.failure(
               Keywords.Any.Not,
-              Messages("any.not", json),
+              ValidatorMessages("any.not", json),
               context.schemaPath,
               context.instancePath,
               json
@@ -99,7 +99,7 @@ object AnyConstraintValidators {
             } else {
               SchemaUtil.failure(
                 Keywords.Any.AllOf,
-                Messages("any.all"),
+                ValidatorMessages("any.all"),
                 context.schemaPath,
                 context.instancePath,
                 json,
@@ -134,7 +134,7 @@ object AnyConstraintValidators {
                 case Nil => Success(json)
                 case errors => SchemaUtil.failure(
                   Keywords.Any.AnyOf,
-                  Messages("any.any"),
+                  ValidatorMessages("any.any"),
                   context.schemaPath,
                   context.instancePath,
                   json,
@@ -159,7 +159,7 @@ object AnyConstraintValidators {
               case 0 =>
                 SchemaUtil.failure(
                   Keywords.Any.OneOf,
-                  Messages("any.one.of.none"),
+                  ValidatorMessages("any.one.of.none"),
                   context.schemaPath,
                   context.instancePath,
                   json,
@@ -174,7 +174,7 @@ object AnyConstraintValidators {
                 }
                 SchemaUtil.failure(
                   Keywords.Any.OneOf,
-                  Messages("any.one.of.many"),
+                  ValidatorMessages("any.one.of.many"),
                   context.schemaPath,
                   context.instancePath,
                   json,
@@ -195,7 +195,7 @@ object AnyConstraintValidators {
           case None => Success(json)
           case Some(constValue) => SchemaUtil.failure(
             "const",
-            Messages("any.const"),
+            ValidatorMessages("any.const"),
             context.schemaPath,
             context.instancePath,
             json,
@@ -215,7 +215,7 @@ object AnyConstraintValidators {
           case Some(values) =>
             SchemaUtil.failure(
               Keywords.Any.Enum,
-              Messages("any.enum"),
+              ValidatorMessages("any.enum"),
               context.schemaPath,
               context.instancePath,
               json,

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayConstraintValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayConstraintValidators.scala
@@ -1,11 +1,10 @@
 package com.eclipsesource.schema.internal.validators
 
 import com.eclipsesource.schema.internal.validation.Rule
-import com.eclipsesource.schema.internal.{Keywords, SchemaUtil}
+import com.eclipsesource.schema.internal.{Keywords, SchemaUtil, ValidatorMessages}
 import com.eclipsesource.schema.{SchemaResolutionContext, SchemaType}
-import com.osinka.i18n.{Lang, Messages}
+import com.osinka.i18n.Lang
 import play.api.libs.json.{JsArray, JsValue}
-
 import scalaz.Success
 
 object ArrayConstraintValidators {
@@ -20,7 +19,7 @@ object ArrayConstraintValidators {
                 .map(Success(_))
                 .getOrElse(SchemaUtil.failure(
                   "contains",
-                  Messages("err.contains"),
+                  ValidatorMessages("err.contains"),
                   context.schemaPath.map(_ \ "contains"),
                   context.instancePath,
                   json
@@ -42,7 +41,7 @@ object ArrayConstraintValidators {
           } else {
             SchemaUtil.failure(
               Keywords.Array.MaxItems,
-              Messages("arr.max", values.size, max),
+              ValidatorMessages("arr.max", values.size, max),
               context.schemaPath,
               context.instancePath,
               json
@@ -64,7 +63,7 @@ object ArrayConstraintValidators {
           } else {
             SchemaUtil.failure(
               Keywords.Array.MinItems,
-              Messages("arr.min", values.size, minItems),
+              ValidatorMessages("arr.min", values.size, minItems),
               context.schemaPath,
               context.instancePath,
               json
@@ -84,7 +83,7 @@ object ArrayConstraintValidators {
           } else {
             SchemaUtil.failure(
               Keywords.Array.UniqueItems,
-              Messages("arr.dups"),
+              ValidatorMessages("arr.dups"),
               context.schemaPath,
               context.instancePath,
               json
@@ -99,7 +98,7 @@ object ArrayConstraintValidators {
                            (implicit lang: Lang) =
     SchemaUtil.failure(
       Keywords.Any.Type,
-      Messages("err.expected.type", "array", SchemaUtil.typeOfAsString(json)),
+      ValidatorMessages("err.expected.type", "array", SchemaUtil.typeOfAsString(json)),
       context.schemaPath,
       context.instancePath,
       json

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ArrayValidator.scala
@@ -1,11 +1,10 @@
 package com.eclipsesource.schema.internal.validators
 
-import com.eclipsesource.schema.{SchemaArray, SchemaResolutionContext}
 import com.eclipsesource.schema.internal.validation.VA
-import com.eclipsesource.schema.internal.{Keywords, Results, SchemaUtil}
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, Results, SchemaUtil, ValidatorMessages}
+import com.eclipsesource.schema.{SchemaArray, SchemaResolutionContext}
+import com.osinka.i18n.Lang
 import play.api.libs.json.{JsArray, JsValue}
-
 import scalaz.{Failure, Success}
 
 
@@ -32,7 +31,7 @@ object ArrayValidator extends SchemaTypeValidator[SchemaArray] {
       case _ =>
         Results.failureWithPath(
           Keywords.Any.Type,
-          Messages("err.expected.type", SchemaUtil.typeOfAsString(json)),
+          ValidatorMessages("err.expected.type", SchemaUtil.typeOfAsString(json)),
           context,
           json
         )

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/CompoundValidator.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/CompoundValidator.scala
@@ -1,8 +1,8 @@
 package com.eclipsesource.schema.internal.validators
-import com.eclipsesource.schema.{CompoundSchemaType, _}
-import com.eclipsesource.schema.internal.{Keywords, Results}
 import com.eclipsesource.schema.internal.validation.VA
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, Results, ValidatorMessages}
+import com.eclipsesource.schema.{CompoundSchemaType, _}
+import com.osinka.i18n.Lang
 import play.api.libs.json.JsValue
 
 object CompoundValidator extends SchemaTypeValidator[CompoundSchemaType] {
@@ -15,7 +15,7 @@ object CompoundValidator extends SchemaTypeValidator[CompoundSchemaType] {
     result.getOrElse(
         Results.failureWithPath(
           Keywords.Any.Type,
-          Messages("comp.no.schema"),
+          ValidatorMessages("comp.no.schema"),
           context,
           json
         )

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/NumberValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/NumberValidators.scala
@@ -3,10 +3,9 @@ package com.eclipsesource.schema.internal.validators
 import com.eclipsesource.schema.SchemaResolutionContext
 import com.eclipsesource.schema.internal.constraints.Constraints.{Maximum, Minimum}
 import com.eclipsesource.schema.internal.validation.Rule
-import com.eclipsesource.schema.internal.{Keywords, SchemaUtil}
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, SchemaUtil, ValidatorMessages}
+import com.osinka.i18n.Lang
 import play.api.libs.json.{JsNumber, JsValue}
-
 import scalaz.Success
 
 object NumberValidators {
@@ -31,9 +30,9 @@ object NumberValidators {
             } else {
               val isExclusive = min.isExclusive.getOrElse(false)
               val msg = if (isExclusive) {
-                Messages("num.min.exclusive", number, min.min)
+                ValidatorMessages("num.min.exclusive", number, min.min)
               } else {
-                Messages("num.min", number, min.min)
+                ValidatorMessages("num.min", number, min.min)
               }
               SchemaUtil.failure(
                 Keywords.Number.Min,
@@ -69,9 +68,9 @@ object NumberValidators {
             } else {
               val isExclusive = max.isExclusive.getOrElse(false)
               val msg = if (isExclusive) {
-                Messages("num.max.exclusive", number, max.max)
+                ValidatorMessages("num.max.exclusive", number, max.max)
               } else {
-                Messages("num.max", number, max.max)
+                ValidatorMessages("num.max", number, max.max)
               }
               SchemaUtil.failure(
                 Keywords.Number.Max,
@@ -97,7 +96,7 @@ object NumberValidators {
             } else {
               SchemaUtil.failure(
                 Keywords.Number.MultipleOf,
-                Messages("num.multiple.of", number, factor),
+                ValidatorMessages("num.multiple.of", number, factor),
                 context.schemaPath,
                 context.instancePath,
                 number
@@ -113,7 +112,7 @@ object NumberValidators {
                             (implicit lang: Lang) =
     SchemaUtil.failure(
       Keywords.Any.Type,
-      Messages("err.expected.type", "number", SchemaUtil.typeOfAsString(json)),
+      ValidatorMessages("err.expected.type", "number", SchemaUtil.typeOfAsString(json)),
       context.schemaPath,
       context.instancePath,
       json
@@ -138,7 +137,7 @@ object NumberValidators {
               } else {
                 SchemaUtil.failure(
                   Keywords.String.Format,
-                  Messages("str.format", number, schemaFormat.name),
+                  ValidatorMessages("str.format", number, schemaFormat.name),
                   context.schemaPath,
                   context.instancePath,
                   json

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/ObjectValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/ObjectValidators.scala
@@ -2,10 +2,10 @@ package com.eclipsesource.schema.internal.validators
 
 import java.util.regex.Pattern
 
-import com.eclipsesource.schema.{SchemaProp, SchemaResolutionContext, SchemaType, SchemaValue}
 import com.eclipsesource.schema.internal.validation.VA
-import com.eclipsesource.schema.internal.{Keywords, Props, Results, ValidationStep}
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, Props, Results, ValidationStep, ValidatorMessages}
+import com.eclipsesource.schema.{SchemaProp, SchemaResolutionContext, SchemaType, SchemaValue}
+import com.osinka.i18n.Lang
 import play.api.libs.json._
 import scalaz.{ReaderWriterState, Success}
 
@@ -48,7 +48,7 @@ object ObjectValidators {
             attr.name ->
               Results.failureWithPath(
                 Keywords.Object.Required,
-                Messages("obj.required.prop", attr.name),
+                ValidatorMessages("obj.required.prop", attr.name),
                 context,
                 json
               ) :: props
@@ -76,7 +76,7 @@ object ObjectValidators {
               val result = req ->
                 Results.failureWithPath(
                   Keywords.Object.Required,
-                  Messages("obj.required.prop", req),
+                  ValidatorMessages("obj.required.prop", req),
                   context,
                   json
                 )
@@ -155,7 +155,7 @@ object ObjectValidators {
               Results.merge(status,
                 Results.failureWithPath(
                   Keywords.Object.AdditionalProperties,
-                  Messages("obj.additional.props", unmatchedFields.map { case (name, _) => s"'$name'" }.mkString(" and ")),
+                  ValidatorMessages("obj.additional.props", unmatchedFields.map { case (name, _) => s"'$name'" }.mkString(" and ")),
                   context,
                   json
                 )
@@ -185,7 +185,7 @@ object ObjectValidators {
       val result = mandatoryProps.map(prop => json.fields.find(_._1 == prop).fold(
         prop -> Results.failureWithPath(
           Keywords.Object.Dependencies,
-          Messages("obj.missing.prop.dep", prop),
+          ValidatorMessages("obj.missing.prop.dep", prop),
           context.updateScope(_.copy(
             schemaJsPath = context.schemaPath.map(_ \ prop),
             instancePath = context.instancePath \ prop
@@ -227,7 +227,7 @@ object ObjectValidators {
           if (size <= max)  Success(json)
           else  Results.failureWithPath(
             Keywords.Object.MaxProperties,
-            Messages("obj.max.props", size, max),
+            ValidatorMessages("obj.max.props", size, max),
             context,
             json
           )
@@ -247,7 +247,7 @@ object ObjectValidators {
         } else {
           Results.failureWithPath(
             Keywords.Object.MinProperties,
-            Messages("obj.min.props", size, min),
+            ValidatorMessages("obj.min.props", size, min),
             context,
             json
           )

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/StringValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/StringValidators.scala
@@ -3,14 +3,14 @@ package com.eclipsesource.schema.internal.validators
 import java.text.BreakIterator
 
 import com.eclipsesource.schema.SchemaResolutionContext
-import com.eclipsesource.schema.internal.{Keywords, SchemaUtil}
 import com.eclipsesource.schema.internal.validation.Rule
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, SchemaUtil, ValidatorMessages}
+import com.osinka.i18n.Lang
 import jdk.nashorn.internal.runtime.regexp.RegExpFactory
 import play.api.libs.json.{JsString, JsValue}
+import scalaz.Success
 
 import scala.util.Try
-import scalaz.Success
 
 object StringValidators {
   def validatePattern(pat: Option[String])(implicit lang: Lang): scalaz.Reader[SchemaResolutionContext, Rule[JsValue, JsValue]] =
@@ -28,7 +28,7 @@ object StringValidators {
                 } else {
                   SchemaUtil.failure(
                     Keywords.String.Pattern,
-                    Messages("str.pattern", string, pattern),
+                    ValidatorMessages("str.pattern", string, pattern),
                     context.schemaPath,
                     context.instancePath,
                     json
@@ -37,7 +37,7 @@ object StringValidators {
             }).getOrElse(
               SchemaUtil.failure(
                 Keywords.String.Pattern,
-                Messages("str.invalid.pattern", pattern),
+                ValidatorMessages("str.invalid.pattern", pattern),
                 context.schemaPath,
                 context.instancePath,
                 json
@@ -59,7 +59,7 @@ object StringValidators {
           } else {
             SchemaUtil.failure(
               Keywords.String.MinLength,
-              Messages("str.min.length", string, minLength),
+              ValidatorMessages("str.min.length", string, minLength),
               context.schemaPath,
               context.instancePath,
               json
@@ -80,7 +80,7 @@ object StringValidators {
             } else {
               SchemaUtil.failure(
                 Keywords.String.MaxLength,
-                Messages("str.max.length", string, max),
+                ValidatorMessages("str.max.length", string, max),
                 context.schemaPath,
                 context.instancePath,
                 json
@@ -110,7 +110,7 @@ object StringValidators {
               } else {
                 SchemaUtil.failure(
                   Keywords.String.Format,
-                  Messages("str.format", string, f.name),
+                  ValidatorMessages("str.format", string, f.name),
                   context.schemaPath,
                   context.instancePath,
                   json

--- a/src/main/scala/com/eclipsesource/schema/internal/validators/TupleValidators.scala
+++ b/src/main/scala/com/eclipsesource/schema/internal/validators/TupleValidators.scala
@@ -1,9 +1,9 @@
 package com.eclipsesource.schema.internal.validators
 
 import com.eclipsesource.schema._
-import com.eclipsesource.schema.internal.{Keywords, Results, SchemaUtil}
 import com.eclipsesource.schema.internal.validation.{Rule, VA}
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, Results, SchemaUtil, ValidatorMessages}
+import com.osinka.i18n.Lang
 import play.api.libs.json._
 import scalaz.{Failure, Success}
 
@@ -32,7 +32,7 @@ object TupleValidators {
           }
         case json@other => SchemaUtil.failure(
           Keywords.Any.Type,
-          Messages("err.expected.type", "array", SchemaUtil.typeOfAsString(other)),
+          ValidatorMessages("err.expected.type", "array", SchemaUtil.typeOfAsString(other)),
           context.schemaPath,
           context.instancePath,
           json
@@ -58,7 +58,7 @@ object TupleValidators {
           Seq(
             Results.failureWithPath(
               Keywords.Array.AdditionalItems,
-              Messages("arr.max", instanceSize, schemaSize),
+              ValidatorMessages("arr.max", instanceSize, schemaSize),
               context,
               json
             )

--- a/src/main/scala/com/eclipsesource/schema/package.scala
+++ b/src/main/scala/com/eclipsesource/schema/package.scala
@@ -4,8 +4,8 @@ import com.eclipsesource.schema.internal.constraints.Constraints.HasAnyConstrain
 import com.eclipsesource.schema.internal.refs._
 import com.eclipsesource.schema.internal.validation.VA
 import com.eclipsesource.schema.internal.validators._
-import com.eclipsesource.schema.internal.{Keywords, Results, SchemaUtil}
-import com.osinka.i18n.{Lang, Messages}
+import com.eclipsesource.schema.internal.{Keywords, Results, SchemaUtil, ValidatorMessages}
+import com.osinka.i18n.Lang
 import play.api.libs.json._
 import scalaz.{-\/, Failure, Success, \/, \/-}
 
@@ -61,7 +61,7 @@ package object schema {
         case (_, SchemaValue(JsBoolean(false))) =>
           Results.failureWithPath(
             "",
-            Messages("err.false.schema", schemaType, SchemaUtil.typeOfAsString(json)),
+            ValidatorMessages("err.false.schema", schemaType, SchemaUtil.typeOfAsString(json)),
             context,
             json)
 
@@ -105,7 +105,7 @@ package object schema {
         case (_, _) =>
           Results.failureWithPath(
             Keywords.Any.Type,
-            Messages("err.expected.type", schemaType, SchemaUtil.typeOfAsString(json)),
+            ValidatorMessages("err.expected.type", schemaType, SchemaUtil.typeOfAsString(json)),
             context,
             json)
       }


### PR DESCRIPTION
Fixes issue #140 by providing default messages if no `messages.txt` resource can be found.